### PR TITLE
add link to ship page (#19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
             "chrome": true
         }
     },
-    "eslintIgnore": [ "src/vendor/**/*.js", "*.min.js" ]
+    "eslintIgnore": [ "src/vendor/**/*.js", "*.min.js" ],
+    "scripts": {
+        "generate-ships-file": "node scripts/generate_ships_file.js"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "jszip": "^3.1.5"
     },
     "devDependencies": {
+        "axios": "^0.21.1",
         "eslint": "^5.0.1"
     },
     "eslintConfig": {
@@ -31,7 +32,10 @@
             "chrome": true
         }
     },
-    "eslintIgnore": [ "src/vendor/**/*.js", "*.min.js" ],
+    "eslintIgnore": [
+        "src/vendor/**/*.js",
+        "*.min.js"
+    ],
     "scripts": {
         "generate-ships-file": "node scripts/generate_ships_file.js"
     }

--- a/scripts/generate_ships_file.js
+++ b/scripts/generate_ships_file.js
@@ -1,0 +1,57 @@
+let fs = require('fs');
+let request = require('request');
+
+const url = 'https://robertsspaceindustries.com/ship-matrix/index';
+const fields = {
+    'name': 'name',
+    'url': 'url',
+    'thumbnail': 'media.0.images.heap_infobox'
+};
+
+request(url, function(error, response, body) {
+
+    if(error) {
+        console.log("Failed because an error occured: ", error);
+        return;
+    }
+
+    if(response.statusCode !== 200) {
+        console.error("Failed to fetch the ship matrix because it returned a non 200 status code. Status code: ", response.statusCode);
+        return;
+    }
+
+    let parsedBody = JSON.parse(body);
+
+    if(parsedBody.success === 1) {
+        let ships = parsedBody.data;
+
+        let processedShips = [];
+        for(let i = 0; i < ships.length; i++) {
+            let ship = ships[i];
+            let data = {};
+
+            for (let key in fields) {
+                let path = fields[key].split('.');
+                let current = ship;
+                for (let j = 0; j < path.length; j++) {
+                    current = current[path[j]];
+                }
+                data[key] = current;
+            }
+
+            processedShips.push(data);
+        }
+        console.log("Fetched %d ships and vehicles", processedShips.length);
+        
+        const content = 'var HangarXPLOR = HangarXPLOR || {};'
+                    + '\n\n' 
+                    + 'HangarXPLOR._ships = ' + JSON.stringify(processedShips, null, '\t');
+        fs.writeFile('src/web_resources/HangarXPLOR.Ships.js', content, "utf-8", function (error) {
+            if (error) {
+                console.error("Failed to write the 'HangarXPLOR.Ships.js' file", error);
+            };
+            console.log("Successfully created the 'HangarXPLOR.Ships.js' file");
+          });
+    }
+
+});

--- a/scripts/generate_ships_file.js
+++ b/scripts/generate_ships_file.js
@@ -10,18 +10,13 @@ const fields = {
 
 axios.get(URL)
     .then((response) => {
-
-        const processedShips = [];
-
-        const axios_promises = [];
-        const missing_shipyard_links = [];
-
         let parsedBody = response.data;
 
         if(parsedBody.success === 1) {
             let ships = parsedBody.data;
 
-            for(let i = 0; i < ships.length; i++) { 
+            let processedShips = [];
+            for(let i = 0; i < ships.length; i++) {
                 let ship = ships[i];
                 let data = {};
 
@@ -32,57 +27,21 @@ axios.get(URL)
                         current = current[path[j]];
                     }
                     data[key] = current;
-
-                    // --- handle the external fleetyard link
-                    if(key === 'url') {
-                        let exploded = current.split('/');
-                        let ship_name =  exploded[exploded.length - 1].toLowerCase();
-
-                        let fleetyard_api_url = ('https://api.fleetyards.net/v1/models/' + ship_name);
-
-                        axios_promises.push(axios.get(fleetyard_api_url).then(function (response) {
-                            data['fleetyard'] = ('https://fleetyards.net/ships/' + response.data.slug);
-                        })
-                        .catch(function (error) {
-                            missing_shipyard_links.push(i);
-                        }));
-                    }
                 }
 
                 processedShips.push(data);
             }
-
-            // --- wait for all fleetyards request to be resolved
-            Promise.all(axios_promises).then(responses => {
-                console.log("Fetched %d ships and vehicles", processedShips.length);
-                console.log("%d missing fleetyard links", missing_shipyard_links.length);
-    
-
-                // --- find missing links
-                if(missing_shipyard_links.length > 0) {
-                    missing_shipyard_links.forEach(ship_id => {
-                        for(let i = 0; i < processedShips.length; i++) {
-                            if(ship_id != i && processedShips[ship_id].name.includes(processedShips[i].name)) {
-                                processedShips[ship_id]['fleetyard'] = processedShips[i]['fleetyard'];
-                            }
-                        }
-                    });
-                }
-                
-                const content = 'var HangarXPLOR = HangarXPLOR || {};'
-                            + '\n\n' 
-                            + 'HangarXPLOR._ships = ' + JSON.stringify(processedShips, null, '\t');
-                fs.writeFile('src/web_resources/HangarXPLOR.Ships.js', content, "utf-8", function (error) {
-                    if (error) {
-                        console.error("Failed to write the 'HangarXPLOR.Ships.js' file", error);
-                    };
-                    console.log("Successfully created the 'HangarXPLOR.Ships.js' file");
-                });
-    
+            console.log("Fetched %d ships and vehicles", processedShips.length);
+            
+            const content = 'var HangarXPLOR = HangarXPLOR || {};'
+                        + '\n\n' 
+                        + 'HangarXPLOR._ships = ' + JSON.stringify(processedShips, null, '\t');
+            fs.writeFile('src/web_resources/HangarXPLOR.Ships.js', content, "utf-8", function (error) {
+                if (error) {
+                    console.error("Failed to write the 'HangarXPLOR.Ships.js' file", error);
+                };
+                console.log("Successfully created the 'HangarXPLOR.Ships.js' file");
             });
-            
-
-            
         }
     })
     .catch(error => {

--- a/scripts/generate_ships_file.js
+++ b/scripts/generate_ships_file.js
@@ -57,13 +57,17 @@ axios.get(URL)
                 console.log("Fetched %d ships and vehicles", processedShips.length);
                 console.log("%d missing fleetyard links", missing_shipyard_links.length);
     
-    
-                // TODO: Handle missing links e.g. some special edition ships do not have their own page on fleetyard... 
-                // if(missing_shipyard_links.length > 0) {
-                //     missing_shipyard_links.forEach(ship_id => {
-                //         
-                //     });
-                // }
+
+                // --- find missing links
+                if(missing_shipyard_links.length > 0) {
+                    missing_shipyard_links.forEach(ship_id => {
+                        for(let i = 0; i < processedShips.length; i++) {
+                            if(ship_id != i && processedShips[ship_id].name.includes(processedShips[i].name)) {
+                                processedShips[ship_id]['fleetyard'] = processedShips[i]['fleetyard'];
+                            }
+                        }
+                    });
+                }
                 
                 const content = 'var HangarXPLOR = HangarXPLOR || {};'
                             + '\n\n' 

--- a/scripts/generate_ships_file.js
+++ b/scripts/generate_ships_file.js
@@ -1,57 +1,58 @@
-let fs = require('fs');
-let request = require('request');
+const fs = require('fs');
+const axios = require('axios');
 
-const url = 'https://robertsspaceindustries.com/ship-matrix/index';
+const URL = 'https://robertsspaceindustries.com/ship-matrix/index'
 const fields = {
     'name': 'name',
     'url': 'url',
     'thumbnail': 'media.0.images.heap_infobox'
 };
 
-request(url, function(error, response, body) {
+axios.get(URL)
+    .then((response) => {
+        let parsedBody = response.data;
 
-    if(error) {
-        console.log("Failed because an error occured: ", error);
-        return;
-    }
+        if(parsedBody.success === 1) {
+            let ships = parsedBody.data;
 
-    if(response.statusCode !== 200) {
-        console.error("Failed to fetch the ship matrix because it returned a non 200 status code. Status code: ", response.statusCode);
-        return;
-    }
+            let processedShips = [];
+            for(let i = 0; i < ships.length; i++) {
+                let ship = ships[i];
+                let data = {};
 
-    let parsedBody = JSON.parse(body);
-
-    if(parsedBody.success === 1) {
-        let ships = parsedBody.data;
-
-        let processedShips = [];
-        for(let i = 0; i < ships.length; i++) {
-            let ship = ships[i];
-            let data = {};
-
-            for (let key in fields) {
-                let path = fields[key].split('.');
-                let current = ship;
-                for (let j = 0; j < path.length; j++) {
-                    current = current[path[j]];
+                for (let key in fields) {
+                    let path = fields[key].split('.');
+                    let current = ship;
+                    for (let j = 0; j < path.length; j++) {
+                        current = current[path[j]];
+                    }
+                    data[key] = current;
                 }
-                data[key] = current;
+
+                processedShips.push(data);
             }
-
-            processedShips.push(data);
+            console.log("Fetched %d ships and vehicles", processedShips.length);
+            
+            const content = 'var HangarXPLOR = HangarXPLOR || {};'
+                        + '\n\n' 
+                        + 'HangarXPLOR._ships = ' + JSON.stringify(processedShips, null, '\t');
+            fs.writeFile('src/web_resources/HangarXPLOR.Ships.js', content, "utf-8", function (error) {
+                if (error) {
+                    console.error("Failed to write the 'HangarXPLOR.Ships.js' file", error);
+                };
+                console.log("Successfully created the 'HangarXPLOR.Ships.js' file");
+            });
         }
-        console.log("Fetched %d ships and vehicles", processedShips.length);
-        
-        const content = 'var HangarXPLOR = HangarXPLOR || {};'
-                    + '\n\n' 
-                    + 'HangarXPLOR._ships = ' + JSON.stringify(processedShips, null, '\t');
-        fs.writeFile('src/web_resources/HangarXPLOR.Ships.js', content, "utf-8", function (error) {
-            if (error) {
-                console.error("Failed to write the 'HangarXPLOR.Ships.js' file", error);
-            };
-            console.log("Successfully created the 'HangarXPLOR.Ships.js' file");
-          });
-    }
+    })
+    .catch(error => {
+        if(error) {
+            console.log(error);
+            return;
+        }
+        if(error.response.status !== 200) {
+            console.error("Failed to fetch the ship matrix because it returned a non 200 status code. Status code: ", error.response.status);
+            return;
+        }
 
-});
+        console.log("Failed because an error occured: ", error);
+    });

--- a/src/web_resources/HangarXPLOR.ProcessItem.js
+++ b/src/web_resources/HangarXPLOR.ProcessItem.js
@@ -184,6 +184,7 @@ HangarXPLOR.ProcessItem = function()
       for (i = 0, j = HangarXPLOR._ships.length; i < j; i++) {
         if (this.shipName.toLowerCase().indexOf(HangarXPLOR._ships[i].name.toLowerCase()) > -1) {
           $('.basic-infos .image', this).css({ 'background-image': 'url("' + HangarXPLOR._ships[i].thumbnail + '")'});
+          $('.items', this).prepend('<a href="' + HangarXPLOR._ships[i].url + '" target="_blank" class="shadow-button trans-02s trans-color"><span class="label js-label trans-02s">Ship Page</span><span class="icon trans-02s"><span class="effect trans-opacity trans-03s"></span></span><span class="left-section"></span><span class="right-section"></span></a>');
           break;
         }
       }

--- a/src/web_resources/HangarXPLOR.ProcessItem.js
+++ b/src/web_resources/HangarXPLOR.ProcessItem.js
@@ -184,7 +184,7 @@ HangarXPLOR.ProcessItem = function()
       for (i = 0, j = HangarXPLOR._ships.length; i < j; i++) {
         if (this.shipName.toLowerCase().indexOf(HangarXPLOR._ships[i].name.toLowerCase()) > -1) {
           $('.basic-infos .image', this).css({ 'background-image': 'url("' + HangarXPLOR._ships[i].thumbnail + '")'});
-          $('.items', this).prepend('<a href="' + (HangarXPLOR._ships[i].fleetyard || HangarXPLOR._ships[i].url) + '" target="_blank" class="shadow-button trans-02s trans-color"><span class="label js-label trans-02s">Ship Page</span><span class="icon trans-02s"><span class="effect trans-opacity trans-03s"></span></span><span class="left-section"></span><span class="right-section"></span></a>');
+          $('.items', this).prepend('<a href="' + HangarXPLOR._ships[i].url + '" target="_blank" class="shadow-button trans-02s trans-color"><span class="label js-label trans-02s">Ship Page</span><span class="icon trans-02s"><span class="effect trans-opacity trans-03s"></span></span><span class="left-section"></span><span class="right-section"></span></a>');
           break;
         }
       }

--- a/src/web_resources/HangarXPLOR.ProcessItem.js
+++ b/src/web_resources/HangarXPLOR.ProcessItem.js
@@ -184,7 +184,7 @@ HangarXPLOR.ProcessItem = function()
       for (i = 0, j = HangarXPLOR._ships.length; i < j; i++) {
         if (this.shipName.toLowerCase().indexOf(HangarXPLOR._ships[i].name.toLowerCase()) > -1) {
           $('.basic-infos .image', this).css({ 'background-image': 'url("' + HangarXPLOR._ships[i].thumbnail + '")'});
-          $('.items', this).prepend('<a href="' + HangarXPLOR._ships[i].url + '" target="_blank" class="shadow-button trans-02s trans-color"><span class="label js-label trans-02s">Ship Page</span><span class="icon trans-02s"><span class="effect trans-opacity trans-03s"></span></span><span class="left-section"></span><span class="right-section"></span></a>');
+          $('.items', this).prepend('<a href="' + (HangarXPLOR._ships[i].fleetyard || HangarXPLOR._ships[i].url) + '" target="_blank" class="shadow-button trans-02s trans-color"><span class="label js-label trans-02s">Ship Page</span><span class="icon trans-02s"><span class="effect trans-opacity trans-03s"></span></span><span class="left-section"></span><span class="right-section"></span></a>');
           break;
         }
       }

--- a/src/web_resources/HangarXPLOR.Ships.js
+++ b/src/web_resources/HangarXPLOR.Ships.js
@@ -1,168 +1,849 @@
-
 var HangarXPLOR = HangarXPLOR || {};
 
 HangarXPLOR._ships = [
-  { 'name': 'Origin 100 Series Pack', 'thumbnail': '/media/jhifpuskfsm4gr/heap_infobox/Origin_100_All_100s_LineUP_Front_sm-Min.jpg' },
-  { 'name': '100i', 'thumbnail': '/media/bapnpk9usqxxhr/heap_infobox/100i.jpg' },
-  { 'name': '125a', 'thumbnail': '/media/vkuyeedcipouyr/heap_infobox/125a.jpg' },
-  { 'name': '135c', 'thumbnail': '/media/j6gp10aglbb0or/heap_infobox/135c.jpg' },
-  { 'name': '300i', 'thumbnail': '/media/ep375pda2jer7r/heap_infobox/300i_storefront_visual.jpg' },
-  { 'name': '315p', 'thumbnail': '/media/o34z1cyxt1um8r/heap_infobox/315p_storefront_visual.jpg' },
-  { 'name': '325a', 'thumbnail': '/media/gdol1g9fswvjcr/heap_infobox/325a_storefront_visual.jpg' },
-  { 'name': '350r', 'thumbnail': '/media/9k0k3orww22zer/heap_infobox/350r.jpg' },
-  { 'name': '600i Executive', 'thumbnail': '/media/ew63gkfbd7ki2r/heap_infobox/600i_02.jpg' },
-  { 'name': '600i Exploration', 'thumbnail': '/media/8sqwytgh6ij03r/heap_infobox/600i-Exploration.jpg' },
-  { 'name': '600i Touring', 'thumbnail': '/media/z642zdp6d3mkzr/heap_infobox/600i-Touring.jpg' },
-  { 'name': '600i', 'thumbnail': '/media/8sqwytgh6ij03r/heap_infobox/600i-Exploration.jpg' },
-  { 'name': '85X', 'thumbnail': '/media/4vht65hve2o1cr/heap_infobox/85_X_city_shot.jpg' },
-  { 'name': '890 JUMP', 'thumbnail': '/media/aokcb6ay0i0jpr/heap_infobox/890_beautyShot-Concept_V01High_NF_140709.jpg' },
-  { 'name': 'Apollo Triage', 'thumbnail': '/media/rb5f1w3fwj91qr/heap_infobox/RSI_Apollo_landed_topview_03_AL_Pj01-Squashed.jpg' },
-  { 'name': 'Apollo', 'thumbnail': '/media/qtbgmjijc8g1vr/heap_infobox/RSI_Apollo_Promo_Recovery_Drone_AL01_PJ01-Squashed.jpg' },
-  { 'name': 'Ares Inferno', 'thumbnail': 'https://media.robertsspaceindustries.com/jkw5h6088fryi/heap_infobox.jpg' },
-  { 'name': 'Ares Ion', 'thumbnail': 'https://media.robertsspaceindustries.com/711aanrxslfo9/heap_infobox.jpg' },
-  { 'name': 'Aurora CL', 'thumbnail': '/media/fh1gtu93mndsur/heap_infobox/Rsi_aurora_cl_storefront_visual.jpg' },
-  { 'name': 'Aurora ES', 'thumbnail': '/media/9u8061zhf29fir/heap_infobox/Rsi_aurora_es_storefront_visual.jpg' },
-  { 'name': 'Aurora LN', 'thumbnail': '/media/ljgowkr9tdwetr/heap_infobox/Rsi_aurora_ln_storefront_visual.jpg' },
-  { 'name': 'Aurora LX', 'thumbnail': '/media/xfq27owiysn6ar/heap_infobox/Aurora-LX_Ortho.jpg' },
-  { 'name': 'Aurora MR', 'thumbnail': '/media/ohbfgn1ebcsnar/heap_infobox/Rsi_aurora_mr_storefront_visual.jpg' },
-  { 'name': 'Aurora', 'thumbnail': '/media/9u8061zhf29fir/heap_infobox/Rsi_aurora_es_storefront_visual.jpg' },
-  { 'name': 'Avenger Stalker', 'thumbnail': '/media/3dx8jqsd79dmpr/heap_infobox/Avenger_storefront_visualjpg.jpg' },
-  { 'name': 'Avenger Titan Renegade', 'thumbnail': '/media/cg2gcecohj7s6r/heap_infobox/Avenger_cargo_right.jpg' },
-  { 'name': 'Avenger Titan', 'thumbnail': '/media/cg2gcecohj7s6r/heap_infobox/Avenger_cargo_right.jpg' },
-  { 'name': 'Avenger Warlock', 'thumbnail': '/media/qcv2n7ms9qwj8r/heap_infobox/Avenger_EMP_02.jpg' },
-  { 'name': 'Avenger', 'thumbnail': '/media/3dx8jqsd79dmpr/heap_infobox/Avenger_storefront_visualjpg.jpg' },
-  { 'name': 'Ballista Dunestalker', 'thumbnail': '/media/rjxw89rs3sk5wr/heap_infobox/Ballista_Dunestalker-Min.jpg' },
-  { 'name': 'Ballista Snowblind', 'thumbnail': '/media/a5nzp9tgvq2i5r/heap_infobox/Ballista_Snowblind-Min.jpg' },
-  { 'name': 'Ballista', 'thumbnail': 'https://media.robertsspaceindustries.com/e6jcsnshfbfy2/heap_infobox.jpg' },
-  { 'name': 'Buccaneer', 'thumbnail': '/media/pz2oqi319v0ptr/heap_infobox/Buccaneer_Landed_02.jpg' },
-  { 'name': 'Blade', 'thumbnail': '/media/nlamsjvlrdywnr/heap_infobox/Blade-Top-Squashed.jpg' },
-  { 'name': 'Carrack', 'thumbnail': '/media/u248nf7opb5bhr/heap_infobox/Carrack_Landed_Final_Gurmukh.png' },
-  { 'name': 'Caterpillar Pirate Edition', 'thumbnail': '/media/56cjes33yzdj6r/heap_infobox/Pirate_05.jpg' },
-  { 'name': 'Caterpillar', 'thumbnail': '/media/t6jowqxe2u8jxr/heap_infobox/Ext-Front-V01.jpg' },
-  { 'name': 'Constellation Andromeda', 'thumbnail': '/media/vzyhde6cjgsn7r/heap_infobox/Andromeda_Storefront.jpg' },
-  { 'name': 'Constellation Aquila', 'thumbnail': '/media/u0pbc9k058nuhr/heap_infobox/Aquila_Storefront.jpg' },
-  { 'name': 'Constellation Phoenix Emerald', 'thumbnail': '/media/kkakjxny421xfr/heap_infobox/Connie_Emerald.jpg' },
-  { 'name': 'Constellation Phoenix', 'thumbnail': 'https://media.robertsspaceindustries.com/mibl3d305r0q6/heap_infobox.png' },
-  { 'name': 'Constellation Taurus', 'thumbnail': '/media/3vj4o4l5uggk7r/heap_infobox/Taurus-Storefront.jpg' },
-  { 'name': 'Constellation', 'thumbnail': '/media/3vj4o4l5uggk7r/heap_infobox/Taurus-Storefront.jpg' },
-  { 'name': 'Crucible', 'thumbnail': '/media/p1ssz5xc0ev53r/heap_infobox/AnvilcrucibleLANDED.jpg' },
-  { 'name': 'Cutlass Black', 'thumbnail': '/media/7tcxllnna6a9hr/heap_infobox/Drake_cutlass_storefront_visual.jpg' },
-  { 'name': 'Cutlass Blue', 'thumbnail': '/media/8d5ywktt23231r/heap_infobox/Blue-WR-Orth_000000.jpg' },
-  { 'name': 'Cutlass Red', 'thumbnail': '/media/anznazc3gf5oar/heap_infobox/Slide_Cut-Red.jpg' },
-  { 'name': 'Cutlass', 'thumbnail': '/media/7tcxllnna6a9hr/heap_infobox/Drake_cutlass_storefront_visual.jpg' },
-  { 'name': 'Cyclone-AA', 'thumbnail': '/media/wk9v710a3544zr/heap_infobox/03_AA_Cyclone-1.jpg' },
-  { 'name': 'Cyclone-RC', 'thumbnail': '/media/jq8ph9r2m9dtbr/heap_infobox/05_RC_Cyclone-1.jpg' },
-  { 'name': 'Cyclone-RN', 'thumbnail': '/media/uwsxls7k000byr/heap_infobox/06_RN_Cyclone.jpg' },
-  { 'name': 'Cyclone-TR', 'thumbnail': '/media/bt0t220cao82ur/heap_infobox/00_TR_Cyclone.jpg' },
-  // { 'name': 'Cyclone', 'thumbnail': '/media/bt0t220cao82ur/heap_infobox/00_TR_Cyclone.jpg' },
-  { 'name': 'Defender', 'thumbnail': '/media/hh9wc0m0r6y5nr/heap_infobox/20170407c-reduced.jpg' },
-  { 'name': 'Eclipse', 'thumbnail': '/media/uqceivqlombzor/heap_infobox/Aegis-Eclipse-L4-Piece-2-Hangar-Presentation-007.jpg' },
-  { 'name': 'Endeavor', 'thumbnail': '/media/vh2jbjaom7ys4r/heap_infobox/CO_Beauty_BioDomes.jpg' },
-  { 'name': 'F7C-M Super Hornet', 'thumbnail': '/media/4otqgybm0y38ur/heap_infobox/F7c-M_super-Hornet_storefront_visual.jpg' },
-  { 'name': 'F7C-R Hornet Tracker', 'thumbnail': '/media/5f5hxp2dp3b69r/heap_infobox/F7c-R_hornet-Tracker_storefront_visual.jpg' },
-  { 'name': 'F7C-S Hornet Ghost', 'thumbnail': '/media/d7l12zt956s62r/heap_infobox/F7cs_hornet_ghost_storefront_visual.jpg' },
-  { 'name': 'F7C Hornet Wildfire', 'thumbnail': '/media/0ioeh7g90gnqsr/heap_infobox/Wildfire_render1.jpg' },
-  { 'name': 'F7C Hornet', 'thumbnail': '/media/m6e374a9zb7dlr/heap_infobox/F7c_hornet_storefront_visual.jpg' },
-  { 'name': 'Freelancer DUR', 'thumbnail': '/media/gui7c4ac9u4v3r/heap_infobox/Freelancer_dur_storefront_visual.jpg' },
-  { 'name': 'Freelancer MAX', 'thumbnail': '/media/pd2zoaytunmrkr/heap_infobox/Freelancer_max_storefront_visual.jpg' },
-  { 'name': 'Freelancer MIS', 'thumbnail': '/media/yie4k1qvzqqr0r/heap_infobox/Freelancer_mis_storefront_visual.jpg' },
-  { 'name': 'Freelancer', 'thumbnail': '/media/ts39qbhy6x38pr/heap_infobox/Freelancer_storefront_visual.jpg' },
-  { 'name': 'G12A', 'thumbnail': 'https://media.robertsspaceindustries.com/pahu0o7jdshco/heap_infobox.jpg' },
-  { 'name': 'G12R', 'thumbnail': 'https://media.robertsspaceindustries.com/bml1upk14o5re/heap_infobox.jpg' },
-  { 'name': 'G12', 'thumbnail': 'https://media.robertsspaceindustries.com/s7f45fxzm59py/heap_infobox.jpg' },
-  { 'name': 'Genesis', 'thumbnail': '/media/iqk7vt4xay0zfr/heap_infobox/Starliner_action1_runwaycompFlat.jpg' },
-  { 'name': 'Gladiator', 'thumbnail': '/media/qjmsm4fedkty7r/heap_infobox/Gladiator.png' },
-  { 'name': 'Gladius Pirate Edition', 'thumbnail': '/media/mpszlemby5r43r/heap_infobox/Gladius_variant_sale_img.jpg' },
-  { 'name': 'Gladius Valiant', 'thumbnail': '/media/mpszlemby5r43r/heap_infobox/Gladius_variant_sale_img.jpg' },
-  { 'name': 'Gladius', 'thumbnail': '/media/b623f9bkn0c3ur/heap_infobox/Gladius_Front_Perspective.jpg' },
-  { 'name': 'Glaive', 'thumbnail': '/media/i8jxt206icfbar/heap_infobox/Glaive2comp0059comp2.jpg' },
-  { 'name': 'Hammerhead', 'thumbnail': '/media/o3629jnxrq3bmr/heap_infobox/Hammerhead_Missile_Fire_2.jpg' },
-  { 'name': 'Hawk', 'thumbnail': '/media/4diiopxx6gyr5r/heap_infobox/Ah-Parking-Scene-02.jpg' },
-  { 'name': 'Herald', 'thumbnail': '/media/rq2gv7b4b3id0r/heap_infobox/Herald-1.jpg' },
-  { 'name': 'Hercules Starlifter A2', 'thumbnail': '/media/kct1e9vkx4ld6r/heap_infobox/CRUS_Starlifter_Promo_Gunship_Bombing_MO02-Squashed.jpg' },
-  { 'name': 'Hercules Starlifter C2', 'thumbnail': '/media/7bdt759toqnvhr/heap_infobox/CRUS_Starlifter_Promo_Basic_Landed_MO01-Squashed.jpg' },
-  { 'name': 'Hercules Starlifter M2', 'thumbnail': '/media/p077b9nm14i11r/heap_infobox/CRUS_Starlifter_Promo_Military_Flares_MO01-Squashed.jpg' },
-  { 'name': 'Hornet F7C', 'thumbnail': '/media/m6e374a9zb7dlr/heap_infobox/F7c_hornet_storefront_visual.jpg' },
-  { 'name': 'Hull A', 'thumbnail': '/media/tpw5r365mowmar/heap_infobox/Hull_A_Final.jpg' },
-  { 'name': 'Hull B', 'thumbnail': '/media/xg8d8kyo0bjsmr/heap_infobox/HullB_landedcompv3b.jpg' },
-  { 'name': 'Hull C', 'thumbnail': '/media/w54u21vkhci5vr/heap_infobox/Hull_C_Final.jpg' },
-  { 'name': 'Hull D', 'thumbnail': '/media/wox7k753a2pn6r/heap_infobox/Hull_D_Blueprint.jpg' },
-  { 'name': 'Hull E', 'thumbnail': '/media/xyt1qu08sjmy3r/heap_infobox/Hull_E_3_compflat.jpg' },
-  { 'name': 'Hurricane', 'thumbnail': '/media/vnqcqb3nj47rnr/heap_infobox/Hangar2-Copy.jpg' },
-  { 'name': 'Idris-M', 'thumbnail': '/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg' },
-  { 'name': 'Idris-P', 'thumbnail': '/media/okj4yh84jq9f2r/heap_infobox/IDRISuprearquarter-Copy.jpg' }, // /media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg' },
-  { 'name': 'Javelin-Class Destroyer', 'thumbnail': '/media/nzqi87nkarvupr/heap_infobox/Javelin-Sale.jpg' },
-  { 'name': 'Javelin', 'thumbnail': '/media/nzqi87nkarvupr/heap_infobox/Javelin-Sale.jpg' },
-  { 'name': 'Kraken Privateer', 'thumbnail': 'https://media.robertsspaceindustries.com/vz94xqyun7q6q/heap_infobox.jpg' },
-  { 'name': 'Kraken', 'thumbnail': 'https://media.robertsspaceindustries.com/vz94xqyun7q6q/heap_infobox.jpg' },
-  { 'name': 'Khartu-Al', 'thumbnail': '/media/zzycyqkpn9vu8r/heap_infobox/Image_landed.jpg' },
-  { 'name': 'F8C Lightning Civilian', 'thumbnail': '/media/6yu51ic3y27b6r/heap_infobox/F8C.png' },
-  { 'name': 'F8C Lightning Executive', 'thumbnail': '/media/ldeqyuto9lb46r/heap_infobox/F8C-Executive.png' },
-  { 'name': 'M50', 'thumbnail': '/media/q1jk89gqz2231r/heap_infobox/Jumppoint-Final-Crop.jpg' },
-  { 'name': 'Mantis', 'thumbnail': 'https://media.robertsspaceindustries.com/y3abkhxhriuvc/heap_infobox.jpg' },
-  { 'name': 'Merchantman', 'thumbnail': '/media/d8ktckex1ucmrr/heap_infobox/Banu3.jpg' }, // /media/63lxivb7mi3vzr/heap_infobox/Banu_merchantman_side_Version_A.jpg
-  { 'name': 'Mercury', 'thumbnail': '/media/irj2hkopf9043r/heap_infobox/Crusader3-Min.jpeg' },
-  { 'name': 'MPUV Cargo', 'thumbnail': '/media/czio0bw0x1v6cr/heap_infobox/BatCave_4k_v02right2.jpg' },
-  { 'name': 'MPUV Personnel', 'thumbnail': '/media/fgi7cen4bdvzkr/heap_infobox/Landing_v01.jpg' },
-  { 'name': 'Mustang Alpha Vindicator', 'thumbnail': 'https://media.robertsspaceindustries.com/iohmvf24h4rsz/heap_infobox.png' },
-  { 'name': 'Mustang Alpha', 'thumbnail': '/media/ssh2spko70pz6r/heap_infobox/Alpha-Front.jpg' },
-  { 'name': 'Mustang Beta', 'thumbnail': '/media/ltw03c5rli6uwr/heap_infobox/Beta-Front.jpg' },
-  { 'name': 'Mustang Delta', 'thumbnail': '/media/dtqy8jpl0f9cbr/heap_infobox/Delta-Front.jpg' },
-  { 'name': 'Mustang Gamma', 'thumbnail': '/media/yu4cuzh90oz54r/heap_infobox/Gamma-Front.jpg' },
-  { 'name': 'Mustang Omega', 'thumbnail': '/media/gmru9y7ynd1bbr/heap_infobox/Omega-Front.jpg' },
-  { 'name': 'Nautilus Solstice', 'thumbnail': '/media/odq6eby24dbp1r/heap_infobox/AEGIS_Nautilus_Promo_PaintScheme_Concierge_PJ01-Min.png' },
-  { 'name': 'Nautilus', 'thumbnail': 'https://media.robertsspaceindustries.com/41iuhrvh5p2zb/heap_infobox.jpg' },
-  { 'name': 'Nomad', 'thumbnail': 'https://media.robertsspaceindustries.com/fcqc4k2uwgpbr/heap_infobox.jpg' },
-  { 'name': 'Nova Tank', 'thumbnail': '/media/ul5zp2zllebm2r/heap_infobox/TMBL_HeavyTank_ShotG_PJ03-Squashed.jpg' },
-  { 'name': 'Nox Kue', 'thumbnail': '/media/z676k3irx41iur/heap_infobox/NoxKue-Left.jpg' },
-  { 'name': 'Nox', 'thumbnail': '/media/3y2kl543u5n4qr/heap_infobox/Nox-Left.jpg' },
-  { 'name': 'Orion', 'thumbnail': '/media/hfpnkupg7gr6er/heap_infobox/RSI_Orion_Situ1b_150219_GH.jpg' },
-  { 'name': 'P-52 Merlin', 'thumbnail': '/media/a9231ysz5cnvor/heap_infobox/Top.jpg' },
-  { 'name': 'P-72 Archimedes Emerald', 'thumbnail': 'https://media.robertsspaceindustries.com/wonpc3ujtlg9k/heap_infobox.jpg' },
-  { 'name': 'P-72 Archimedes', 'thumbnail': '/media/xqgbgw3x6o54ir/heap_infobox/Archimedes_Front_01.jpg' },
-  { 'name': 'Pioneer', 'thumbnail': '/media/of1es6gu4pa4ir/heap_infobox/Alderin-Landed-Snow-Shot.jpg' },
-  { 'name': 'Pisces Expedition', 'thumbnail': 'https://media.robertsspaceindustries.com/kj7oh12zn2f1l/heap_infobox.jpg' },
-  { 'name': 'Pisces', 'thumbnail': 'https://media.robertsspaceindustries.com/9y6uxd82fw0ne/heap_infobox.jpg' },
-  { 'name': 'Polaris', 'thumbnail': '/media/jv2ayxfguiu57r/heap_infobox/Polaris-Landed.jpg' },
-  { 'name': 'Prospector', 'thumbnail': '/media/smfwnj15y4gq5r/heap_infobox/MISC-Mining-Vehicle-PIECE-2-V19.jpg' },
-  { 'name': 'Prowler', 'thumbnail': '/media/3j9cau4jygwier/heap_infobox/Esperia_Prowler_SHOT_01b.jpg' },
-  { 'name': 'Razor EX', 'thumbnail': '/media/dnlz9p3jx9ll7r/heap_infobox/2-Razor-Flight-Squashed.jpg' },
-  { 'name': 'Razor LX', 'thumbnail': '/media/q9uluuv7z01y7r/heap_infobox/3-LX-City-Flight-Squashed.jpg' },
-  { 'name': 'Razor', 'thumbnail': '/media/18235dq8cydhur/heap_infobox/Misc-Razer-Murray-Ringz-Paint-V5.jpg' }, // '/media/ignbfgsun0k0hr/heap_infobox/Misc-Razer-Pit-Crew-V4.jpg' },
-  { 'name': 'Reclaimer', 'thumbnail': '/media/627hob4lwqt3xr/heap_infobox/Image002-1.jpg' },
-  { 'name': 'Redeemer', 'thumbnail': '/media/t0opqw0tauo45r/heap_infobox/Red1.jpg' },
-  { 'name': 'Reliant Kore - Mini Hauler', 'thumbnail': '/media/rh3sstehu678br/heap_infobox/Reliant_Kore_01.jpg' },
-  { 'name': 'Reliant Tana - Skirmisher', 'thumbnail': '/media/xr1qiks5uct2rr/heap_infobox/Skirmisher_InSitu_AttackChase_Final_Hobbins.jpeg' },
-  { 'name': 'Reliant Sen - Researcher', 'thumbnail': '/media/78ql1skg8yjavr/heap_infobox/Researcher_Insitu_ExploringGasGiantsMoons_Final_Hobbins.jpeg' },
-  { 'name': 'Reliant Mako - News Van', 'thumbnail': '/media/uql843xerchrrr/heap_infobox/NewsVanTracker_Insitu_RaceCapture_Final_Hobbins.jpeg' },
-  { 'name': 'Reliant', 'thumbnail': '/media/jjs1n85qx4u7br/heap_infobox/Reliant_LandingInsitu_Final_Hobbins.png' },
-  { 'name': 'Retaliator Base', 'thumbnail': '/media/bp86xpkhi47etr/heap_infobox/Retaliator_engine_shot_a.jpg' },
-  { 'name': 'Retaliator Bomber', 'thumbnail': '/media/kz6mu0tt0u06er/heap_infobox/Retaliator-Ortho_v2.jpg' },
-  { 'name': 'Retaliator', 'thumbnail': '/media/kz6mu0tt0u06er/heap_infobox/Retaliator-Ortho_v2.jpg' },
-  { 'name': 'ROC', 'thumbnail': 'https://media.robertsspaceindustries.com/u39m0vmntr3pk/heap_infobox.jpg' },
-  { 'name': 'Sabre Comet', 'thumbnail': '/media/8pmglyd0scvhar/heap_infobox/Sabre_variant_sale_img.jpg' },
-  { 'name': 'Sabre Raven', 'thumbnail': '/media/l2eiovh45ypuyr/heap_infobox/RavenTop_Masked.jpg' },
-  { 'name': 'Sabre', 'thumbnail': '/media/wnqvrpoomrpp6r/heap_infobox/Concept_citcon2015_5.jpg' },
-  { 'name': 'Scythe', 'thumbnail': '/media/mlnz0gdyefdmyr/heap_infobox/Vanduul-Scythe_flight_visual.jpg' },
-  { 'name': 'SRV', 'thumbnail': '/media/v5lxymbukofr3/heap_infobox.jpg' },
-  { 'name': 'Starfarer Gemini', 'thumbnail': '/media/4pgpl7n71hijzr/heap_infobox/Gemini2338.jpg' },
-  { 'name': 'Starfarer', 'thumbnail': '/media/k4f44vqnex0m1r/heap_infobox/SF-Chris-O-2.jpg' },
-  { 'name': 'Talon Shrike', 'thumbnail': 'https://media.robertsspaceindustries.com/h2kfgwyfc656i/heap_infobox.jpg' },
-  { 'name': 'Talon', 'thumbnail': 'https://media.robertsspaceindustries.com/5aou1wl6cnihj/heap_infobox.jpg' },
-  { 'name': 'Terrapin', 'thumbnail': '/media/lbhilnq9i8t2mr/heap_infobox/Anvil_Terrapin_Piece_03_Surveilance_v3.jpg' },
-  { 'name': 'Valkyrie Liberator', 'thumbnail': '/media/l87lynolh4pxyr/heap_infobox/128934g7tt.jpg' },
-  { 'name': 'Valkyrie', 'thumbnail': '/media/2fsa0bb3f4e19r/heap_infobox/Valkyrie-Blue-Formation.png' },
-  { 'name': 'Vanduul Blade', 'thumbnail': '/media/d63g0lqsljoyfr/heap_infobox/01.jpg' },
-  { 'name': 'Vanguard Hoplite', 'thumbnail': '/media/zwyyyap3aa7wwr/heap_infobox/Aegis_Vanguard_Hoplite_01.jpg' },
-  { 'name': 'Vanguard Harbinger', 'thumbnail': '/media/c5vioobscp9vkr/heap_infobox/02.jpg' },
-  { 'name': 'Vanguard Sentinel', 'thumbnail': '/media/qqmzhgb7ra29xr/heap_infobox/03.jpg' },
-  { 'name': 'Vanguard Warden', 'thumbnail': '/media/4bnuwyj849f3hr/heap_infobox/Vanguard_34_final_Bachiller_02.png' },
-  { 'name': 'Vanguard', 'thumbnail': '/media/4bnuwyj849f3hr/heap_infobox/Vanguard_34_final_Bachiller_02.png' },
-  { 'name': 'Vulcan', 'thumbnail': '/media/shj3bowjd33umr/heap_infobox/AEGS_Vulcan_ToTheRescueFinal_001b.jpg' },
-  { 'name': 'Vulture', 'thumbnail': '/media/me9lsb0sr41kzr/heap_infobox/Vulture_mechanic.jpg' },
-  { 'name': 'Xi\'an Scout', 'thumbnail': '/media/zzycyqkpn9vu8r/heap_infobox/Image_landed.jpg' },
-  { 'name': 'X1 Baseline Scarlet Edition', 'thumbnail': '/media/3yoh7gun89r8ir/heap_infobox/X1_red_lmt_edition_skin.png' },
-  { 'name': 'X1 Velocity', 'thumbnail': '/media/db18k7yq7s9x0r/heap_infobox/X1_racing_skin.png' },
-  { 'name': 'X1 Force', 'thumbnail': '/media/y5wp16jpen045r/heap_infobox/X1_stealth_skin.png' },
-  { 'name': 'X1 Base', 'thumbnail': '/media/ktxtqr3rikt88r/heap_infobox/X1_base_white.png' },
+	{
+		"name": "Aurora ES",
+		"url": "/pledge/ships/rsi-aurora/Aurora-ES",
+		"thumbnail": "https://media.robertsspaceindustries.com/pnxa8gu3m0wut/heap_infobox.jpg"
+	},
+	{
+		"name": "Aurora LX",
+		"url": "/pledge/ships/rsi-aurora/Aurora-LX",
+		"thumbnail": "https://media.robertsspaceindustries.com/n08kif9wp2t94/heap_infobox.jpg"
+	},
+	{
+		"name": "Aurora MR",
+		"url": "/pledge/ships/rsi-aurora/Aurora-MR",
+		"thumbnail": "https://media.robertsspaceindustries.com/7zbk19qeqy9fp/heap_infobox.jpg"
+	},
+	{
+		"name": "Aurora CL",
+		"url": "/pledge/ships/rsi-aurora/Aurora-CL",
+		"thumbnail": "https://media.robertsspaceindustries.com/eqexi7735yer1/heap_infobox.jpg"
+	},
+	{
+		"name": "Aurora LN",
+		"url": "/pledge/ships/rsi-aurora/Aurora-LN",
+		"thumbnail": "https://media.robertsspaceindustries.com/0ufx8v9k7kult/heap_infobox.jpg"
+	},
+	{
+		"name": "300i",
+		"url": "/pledge/ships/origin-300/300i",
+		"thumbnail": "https://media.robertsspaceindustries.com/q5d6d32fzus8s/heap_infobox.jpg"
+	},
+	{
+		"name": "315p",
+		"url": "/pledge/ships/origin-300/315p",
+		"thumbnail": "https://media.robertsspaceindustries.com/zd6vxsvdq0gxp/heap_infobox.jpg"
+	},
+	{
+		"name": "325a",
+		"url": "/pledge/ships/origin-300/325a",
+		"thumbnail": "https://media.robertsspaceindustries.com/eesg17ack8awh/heap_infobox.jpg"
+	},
+	{
+		"name": "350r",
+		"url": "/pledge/ships/origin-300/350r",
+		"thumbnail": "https://media.robertsspaceindustries.com/7mk0roegof8jp/heap_infobox.jpg"
+	},
+	{
+		"name": "F7C Hornet",
+		"url": "/pledge/ships/anvil-hornet/F7C-Hornet",
+		"thumbnail": "https://media.robertsspaceindustries.com/tcpakf2m1h1hx/heap_infobox.jpg"
+	},
+	{
+		"name": "F7C Hornet Wildfire",
+		"url": "/pledge/ships/anvil-hornet/F7C-Hornet-Wildfire",
+		"thumbnail": "/media/0ioeh7g90gnqsr/heap_infobox/Wildfire_render1.jpg"
+	},
+	{
+		"name": "F7C-S Hornet Ghost",
+		"url": "/pledge/ships/anvil-hornet/F7C-S-Hornet-Ghost",
+		"thumbnail": "https://media.robertsspaceindustries.com/nbwncbo1436rs/heap_infobox.jpg"
+	},
+	{
+		"name": "F7C-R Hornet Tracker",
+		"url": "/pledge/ships/anvil-hornet/F7C-R-Hornet-Tracker",
+		"thumbnail": "https://media.robertsspaceindustries.com/biy2mmvcz6eb2/heap_infobox.jpg"
+	},
+	{
+		"name": "F7C-M Super Hornet",
+		"url": "/pledge/ships/anvil-hornet/F7C-M-Super-Hornet",
+		"thumbnail": "https://media.robertsspaceindustries.com/pjudaw3yj3odo/heap_infobox.jpg"
+	},
+	{
+		"name": "F7A Hornet",
+		"url": "/pledge/ships/anvil-hornet/F7A-Hornet",
+		"thumbnail": "/media/j2ie1gy9x9zsbr/heap_infobox/F7a.jpg"
+	},
+	{
+		"name": "F7C-M Super Hornet Heartseeker",
+		"url": "/pledge/ships/anvil-hornet/F7C-M-Super-Hornet-Heartseeker",
+		"thumbnail": "https://media.robertsspaceindustries.com/6ewzke6o3llh6/heap_infobox.jpg"
+	},
+	{
+		"name": "Constellation Aquila",
+		"url": "/pledge/ships/rsi-constellation/Constellation-Aquila",
+		"thumbnail": "https://media.robertsspaceindustries.com/c2k21tjgn3z6a/heap_infobox.jpg"
+	},
+	{
+		"name": "Constellation Andromeda",
+		"url": "/pledge/ships/rsi-constellation/Constellation-Andromeda",
+		"thumbnail": "https://media.robertsspaceindustries.com/b5wlk3qo9v3iq/heap_infobox.jpg"
+	},
+	{
+		"name": "Constellation Taurus",
+		"url": "/pledge/ships/rsi-constellation/Constellation-Taurus",
+		"thumbnail": "/media/3vj4o4l5uggk7r/heap_infobox/Taurus-Storefront.jpg"
+	},
+	{
+		"name": "Constellation Phoenix",
+		"url": "/pledge/ships/rsi-constellation/Constellation-Phoenix",
+		"thumbnail": "https://media.robertsspaceindustries.com/jkyny550a90um/heap_infobox.jpg"
+	},
+	{
+		"name": "Constellation Phoenix Emerald",
+		"url": "/pledge/ships/rsi-constellation/Constellation-Phoenix-Emerald",
+		"thumbnail": "/media/kkakjxny421xfr/heap_infobox/Connie_Emerald.jpg"
+	},
+	{
+		"name": "Freelancer",
+		"url": "/pledge/ships/misc-freelancer/Freelancer",
+		"thumbnail": "https://media.robertsspaceindustries.com/z3mllk6zi0x7r/heap_infobox.jpg"
+	},
+	{
+		"name": "Freelancer DUR",
+		"url": "/pledge/ships/misc-freelancer/Freelancer-DUR",
+		"thumbnail": "https://media.robertsspaceindustries.com/d5tl8fqymjuf7/heap_infobox.png"
+	},
+	{
+		"name": "Freelancer MAX",
+		"url": "/pledge/ships/misc-freelancer/Freelancer-MAX",
+		"thumbnail": "https://media.robertsspaceindustries.com/tllo2q10dvzmi/heap_infobox.png"
+	},
+	{
+		"name": "Freelancer MIS",
+		"url": "/pledge/ships/misc-freelancer/Freelancer-MIS",
+		"thumbnail": "https://media.robertsspaceindustries.com/ybkygputhkx0g/heap_infobox.jpg"
+	},
+	{
+		"name": "Cutlass Black",
+		"url": "/pledge/ships/drake-cutlass/Cutlass-Black",
+		"thumbnail": "https://media.robertsspaceindustries.com/wj92rqzvhnecb/heap_infobox.jpg"
+	},
+	{
+		"name": "Cutlass Red",
+		"url": "/pledge/ships/drake-cutlass/Cutlass-Red",
+		"thumbnail": "https://media.robertsspaceindustries.com/c93bnty7qmhzb/heap_infobox.jpg"
+	},
+	{
+		"name": "Cutlass Blue",
+		"url": "/pledge/ships/drake-cutlass/Cutlass-Blue",
+		"thumbnail": "https://media.robertsspaceindustries.com/r7z7uznkhwojt/heap_infobox.jpg"
+	},
+	{
+		"name": "Cutlass Black Best In Show Edition",
+		"url": "/pledge/ships/drake-cutlass/Cutlass-Black-Best-In-Show-Edition",
+		"thumbnail": "https://media.robertsspaceindustries.com/vt0f0g30nua1v/heap_infobox.jpg"
+	},
+	{
+		"name": "Avenger Stalker",
+		"url": "/pledge/ships/aegis-avenger/Avenger-Stalker",
+		"thumbnail": "https://media.robertsspaceindustries.com/9tfhza1twrczn/heap_infobox.jpg"
+	},
+	{
+		"name": "Avenger Titan Renegade",
+		"url": "/pledge/ships/aegis-avenger/Avenger-Titan-Renegade",
+		"thumbnail": "https://media.robertsspaceindustries.com/oc8p2v3n7c0e0/heap_infobox.jpg"
+	},
+	{
+		"name": "Avenger Warlock",
+		"url": "/pledge/ships/aegis-avenger/Avenger-Warlock",
+		"thumbnail": "https://media.robertsspaceindustries.com/l8znbwwoh2o8u/heap_infobox.jpg"
+	},
+	{
+		"name": "Avenger Titan",
+		"url": "/pledge/ships/aegis-avenger/Avenger-Titan",
+		"thumbnail": "https://media.robertsspaceindustries.com/fmhdkmvhi8ify/heap_infobox.jpg"
+	},
+	{
+		"name": "Gladiator",
+		"url": "/pledge/ships/anvil-gladiator/Gladiator",
+		"thumbnail": "/media/ye6hvyo93oc2ar/heap_infobox/Gladiator-WB_FrontLeft.jpg"
+	},
+	{
+		"name": "M50",
+		"url": "/pledge/ships/origin-m50/M50",
+		"thumbnail": "https://media.robertsspaceindustries.com/rdj7iilxxhvet/heap_infobox.jpg"
+	},
+	{
+		"name": "Starfarer",
+		"url": "/pledge/ships/misc-starfarer/Starfarer",
+		"thumbnail": "https://media.robertsspaceindustries.com/5ukbyxyx8t6ek/heap_infobox.jpg"
+	},
+	{
+		"name": "Starfarer Gemini",
+		"url": "/pledge/ships/misc-starfarer/Starfarer-Gemini",
+		"thumbnail": "https://media.robertsspaceindustries.com/c6423etmvm52z/heap_infobox.jpg"
+	},
+	{
+		"name": "Caterpillar",
+		"url": "/pledge/ships/drake-caterpillar/Caterpillar",
+		"thumbnail": "https://media.robertsspaceindustries.com/d2lkocbd58mvc/heap_infobox.jpg"
+	},
+	{
+		"name": "Caterpillar Pirate Edition",
+		"url": "/pledge/ships/drake-caterpillar/Caterpillar-Pirate-Edition",
+		"thumbnail": "/media/56cjes33yzdj6r/heap_infobox/Pirate_05.jpg"
+	},
+	{
+		"name": "Caterpillar Best In Show Edition",
+		"url": "/pledge/ships/drake-caterpillar/Caterpillar-Best-In-Show-Edition",
+		"thumbnail": "https://media.robertsspaceindustries.com/1r1vf9peutpr0/heap_infobox.jpg"
+	},
+	{
+		"name": "Retaliator Bomber",
+		"url": "/pledge/ships/aegis-retaliator/Retaliator-Bomber",
+		"thumbnail": "/media/kz6mu0tt0u06er/heap_infobox/Retaliator-Ortho_v2.jpg"
+	},
+	{
+		"name": "Retaliator Base",
+		"url": "/pledge/ships/aegis-retaliator/Retaliator-Base",
+		"thumbnail": "https://media.robertsspaceindustries.com/sa6wyt4so2dtk/heap_infobox.jpg"
+	},
+	{
+		"name": "Scythe",
+		"url": "/pledge/ships/scythe/Scythe",
+		"thumbnail": "/media/wdtdkzl0x31ver/heap_infobox/Vanduul-Scythe_storefront_visual.jpg"
+	},
+	{
+		"name": "Idris-M",
+		"url": "/pledge/ships/aegis-idris/Idris-M",
+		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg"
+	},
+	{
+		"name": "Idris-P",
+		"url": "/pledge/ships/aegis-idris/Idris-P",
+		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg"
+	},
+	{
+		"name": "P-52 Merlin",
+		"url": "/pledge/ships/p52-merlin/P-52-Merlin",
+		"thumbnail": "/media/a9231ysz5cnvor/heap_infobox/Top.jpg"
+	},
+	{
+		"name": "Mustang Alpha",
+		"url": "/pledge/ships/mustang/Mustang-Alpha",
+		"thumbnail": "/media/cpq6ly29wmi1br/heap_infobox/56745675467.jpg"
+	},
+	{
+		"name": "Mustang Beta",
+		"url": "/pledge/ships/mustang/Mustang-Beta",
+		"thumbnail": "/media/4ws8rrspe10exr/heap_infobox/5675676578.jpg"
+	},
+	{
+		"name": "Mustang Gamma",
+		"url": "/pledge/ships/mustang/Mustang-Gamma",
+		"thumbnail": "/media/yu4cuzh90oz54r/heap_infobox/Gamma-Front.jpg"
+	},
+	{
+		"name": "Mustang Delta",
+		"url": "/pledge/ships/mustang/Mustang-Delta",
+		"thumbnail": "https://media.robertsspaceindustries.com/s7ntca9x35tjl/heap_infobox.jpg"
+	},
+	{
+		"name": "Mustang Omega",
+		"url": "/pledge/ships/mustang/Mustang-Omega",
+		"thumbnail": "/media/gmru9y7ynd1bbr/heap_infobox/Omega-Front.jpg"
+	},
+	{
+		"name": "Mustang Alpha Vindicator",
+		"url": "/pledge/ships/mustang/Mustang-Alpha-Vindicator",
+		"thumbnail": "https://media.robertsspaceindustries.com/iohmvf24h4rsz/heap_infobox.png"
+	},
+	{
+		"name": "Redeemer",
+		"url": "/pledge/ships/redeemer/Redeemer",
+		"thumbnail": "/media/t0opqw0tauo45r/heap_infobox/Red1.jpg"
+	},
+	{
+		"name": "Gladius",
+		"url": "/pledge/ships/gladius/Gladius",
+		"thumbnail": "https://media.robertsspaceindustries.com/xxdvidtr1ze6b/heap_infobox.jpg"
+	},
+	{
+		"name": "Gladius Valiant",
+		"url": "/pledge/ships/gladius/Gladius-Valiant",
+		"thumbnail": "/media/mpszlemby5r43r/heap_infobox/Gladius_variant_sale_img.jpg"
+	},
+	{
+		"name": "Pirate Gladius",
+		"url": "/pledge/ships/gladius/Pirate-Gladius",
+		"thumbnail": "https://media.robertsspaceindustries.com/9cwz2utclixvt/heap_infobox.jpg"
+	},
+	{
+		"name": "Khartu-Al",
+		"url": "/pledge/ships/khartu/Khartu-Al",
+		"thumbnail": "https://media.robertsspaceindustries.com/g8xkja21h9rep/heap_infobox.jpg"
+	},
+	{
+		"name": "Merchantman",
+		"url": "/pledge/ships/merchantman/Merchantman",
+		"thumbnail": "https://media.robertsspaceindustries.com/6z00b42zydbnm/heap_infobox.jpg"
+	},
+	{
+		"name": "890 Jump",
+		"url": "/pledge/ships/890-jump/890-Jump",
+		"thumbnail": "https://media.robertsspaceindustries.com/t2bky2nbdg0ms/heap_infobox.jpg"
+	},
+	{
+		"name": "Carrack",
+		"url": "/pledge/ships/carrack/Carrack",
+		"thumbnail": "/media/uacgp8oc20yekr/heap_infobox/Carrack.jpg"
+	},
+	{
+		"name": "Carrack w/C8X",
+		"url": "/pledge/ships/carrack/Carrack-W-C8X",
+		"thumbnail": "https://media.robertsspaceindustries.com/twlkwwqy2mmk2/heap_infobox.jpg"
+	},
+	{
+		"name": "Carrack Expedition w/C8X",
+		"url": "/pledge/ships/carrack/Carrack-Expedition-W-C8X",
+		"thumbnail": "https://media.robertsspaceindustries.com/1k5nfi962y4pp/heap_infobox.jpg"
+	},
+	{
+		"name": "Carrack Expedition",
+		"url": "/pledge/ships/carrack/Carrack-Expedition",
+		"thumbnail": "https://media.robertsspaceindustries.com/gpfapokelyewn/heap_infobox.jpg"
+	},
+	{
+		"name": "Herald",
+		"url": "/pledge/ships/herald/Herald",
+		"thumbnail": "https://media.robertsspaceindustries.com/xcbs8bs50xo23/heap_infobox.jpg"
+	},
+	{
+		"name": "Hull C",
+		"url": "/pledge/ships/hull/Hull-C",
+		"thumbnail": "/media/w54u21vkhci5vr/heap_infobox/Hull_C_Final.jpg"
+	},
+	{
+		"name": "Hull A",
+		"url": "/pledge/ships/hull/Hull-A",
+		"thumbnail": "/media/tpw5r365mowmar/heap_infobox/Hull_A_Final.jpg"
+	},
+	{
+		"name": "Hull B",
+		"url": "/pledge/ships/hull/Hull-B",
+		"thumbnail": "/media/xg8d8kyo0bjsmr/heap_infobox/HullB_landedcompv3b.jpg"
+	},
+	{
+		"name": "Hull D",
+		"url": "/pledge/ships/hull/Hull-D",
+		"thumbnail": "https://media.robertsspaceindustries.com/1j6650dnbblli/heap_infobox.jpg"
+	},
+	{
+		"name": "Hull E",
+		"url": "/pledge/ships/hull/Hull-E",
+		"thumbnail": "/media/xyt1qu08sjmy3r/heap_infobox/Hull_E_3_compflat.jpg"
+	},
+	{
+		"name": "Orion",
+		"url": "/pledge/ships/orion/Orion",
+		"thumbnail": "/media/hfpnkupg7gr6er/heap_infobox/RSI_Orion_Situ1b_150219_GH.jpg"
+	},
+	{
+		"name": "Reclaimer",
+		"url": "/pledge/ships/reclaimer/Reclaimer",
+		"thumbnail": "https://media.robertsspaceindustries.com/iweivr5xyt5j1/heap_infobox.jpg"
+	},
+	{
+		"name": "Reclaimer Best In Show Edition",
+		"url": "/pledge/ships/reclaimer/Reclaimer-Best-In-Show-Edition",
+		"thumbnail": "https://media.robertsspaceindustries.com/81432ksmdzn30/heap_infobox.jpg"
+	},
+	{
+		"name": "Javelin",
+		"url": "/pledge/ships/aegis-javelin/Javelin",
+		"thumbnail": "https://media.robertsspaceindustries.com/oc89p5ksizcla/heap_infobox.jpg"
+	},
+	{
+		"name": "Vanguard Warden",
+		"url": "/pledge/ships/vanguard/Vanguard-Warden",
+		"thumbnail": "https://media.robertsspaceindustries.com/sgzm3dw5q0o3y/heap_infobox.jpg"
+	},
+	{
+		"name": "Vanguard Harbinger",
+		"url": "/pledge/ships/vanguard/Vanguard-Harbinger",
+		"thumbnail": "https://media.robertsspaceindustries.com/enygi6572pnkl/heap_infobox.jpg"
+	},
+	{
+		"name": "Vanguard Sentinel",
+		"url": "/pledge/ships/vanguard/Vanguard-Sentinel",
+		"thumbnail": "https://media.robertsspaceindustries.com/4e4e30eyvq6d6/heap_infobox.jpg"
+	},
+	{
+		"name": "Vanguard Hoplite",
+		"url": "/pledge/ships/vanguard/Vanguard-Hoplite",
+		"thumbnail": "/media/zwyyyap3aa7wwr/heap_infobox/Aegis_Vanguard_Hoplite_01.jpg"
+	},
+	{
+		"name": "Reliant Kore",
+		"url": "/pledge/ships/reliant/Reliant-Kore",
+		"thumbnail": "https://media.robertsspaceindustries.com/hyi1vmyi6ppj6/heap_infobox.jpg"
+	},
+	{
+		"name": "Reliant Mako",
+		"url": "/pledge/ships/reliant/Reliant-Mako",
+		"thumbnail": "https://media.robertsspaceindustries.com/awmk2vgihtpf9/heap_infobox.jpg"
+	},
+	{
+		"name": "Reliant Sen",
+		"url": "/pledge/ships/reliant/Reliant-Sen",
+		"thumbnail": "https://media.robertsspaceindustries.com/8ewkdvinyoy4c/heap_infobox.jpg"
+	},
+	{
+		"name": "Reliant Tana",
+		"url": "/pledge/ships/reliant/Reliant-Tana",
+		"thumbnail": "https://media.robertsspaceindustries.com/qe3ifzhvxdcww/heap_infobox.jpg"
+	},
+	{
+		"name": "Genesis Starliner",
+		"url": "/pledge/ships/starliner/Genesis-Starliner",
+		"thumbnail": "/media/iqk7vt4xay0zfr/heap_infobox/Starliner_action1_runwaycompFlat.jpg"
+	},
+	{
+		"name": "Glaive",
+		"url": "/pledge/ships/esperia-glaive/Glaive",
+		"thumbnail": "https://media.robertsspaceindustries.com/gk4dk2ip4w1ia/heap_infobox.jpg"
+	},
+	{
+		"name": "Endeavor",
+		"url": "/pledge/ships/misc-endeavor/Endeavor",
+		"thumbnail": "/media/vh2jbjaom7ys4r/heap_infobox/CO_Beauty_BioDomes.jpg"
+	},
+	{
+		"name": "Sabre",
+		"url": "/pledge/ships/sabre/Sabre",
+		"thumbnail": "https://media.robertsspaceindustries.com/p32tq6jjp301r/heap_infobox.jpg"
+	},
+	{
+		"name": "Sabre Comet",
+		"url": "/pledge/ships/sabre/Sabre-Comet",
+		"thumbnail": "/media/8pmglyd0scvhar/heap_infobox/Sabre_variant_sale_img.jpg"
+	},
+	{
+		"name": "Sabre Raven",
+		"url": "/pledge/ships/sabre/Sabre-Raven",
+		"thumbnail": "/media/3q1dirw16ezv5r/heap_infobox/3_4_front_raven_blue_Enlarge_Crop.jpg"
+	},
+	{
+		"name": "Crucible",
+		"url": "/pledge/ships/crucible/Crucible",
+		"thumbnail": "https://media.robertsspaceindustries.com/q81gvelwf2usv/heap_infobox.jpg"
+	},
+	{
+		"name": "P72 Archimedes",
+		"url": "/pledge/ships/p72-archimedes/P72-Archimedes",
+		"thumbnail": "/media/xqgbgw3x6o54ir/heap_infobox/Archimedes_Front_01.jpg"
+	},
+	{
+		"name": "P72 Archimedes Emerald",
+		"url": "/pledge/ships/p72-archimedes/P72-Archimedes-Emerald",
+		"thumbnail": "/media/o94ip9isoyjmhr/heap_infobox/Archimedes-Sku-Image-V3.jpg"
+	},
+	{
+		"name": "Blade",
+		"url": "/pledge/ships/vanduul-blade/Blade",
+		"thumbnail": "https://media.robertsspaceindustries.com/hyp6k1cu5qh8a/heap_infobox.jpg"
+	},
+	{
+		"name": "Prospector",
+		"url": "/pledge/ships/misc-prospector/Prospector",
+		"thumbnail": "https://media.robertsspaceindustries.com/bsrfd5pqb769v/heap_infobox.jpg"
+	},
+	{
+		"name": "Buccaneer",
+		"url": "/pledge/ships/drake-buccaneer/Buccaneer",
+		"thumbnail": "/media/eiua12z9nxlkar/heap_infobox/Buc_final120_compFlat.jpg"
+	},
+	{
+		"name": "Dragonfly Yellowjacket",
+		"url": "/pledge/ships/drake-dragonfly/Dragonfly-Yellowjacket",
+		"thumbnail": "/media/am12jusvbx8mqr/heap_infobox/Dragonfly-Left.jpg"
+	},
+	{
+		"name": "Dragonfly Black",
+		"url": "/pledge/ships/drake-dragonfly/Dragonfly-Black",
+		"thumbnail": "/media/5v25a4lwtbdlar/heap_infobox/Dragonfly-Black-Left.jpg"
+	},
+	{
+		"name": "MPUV Personnel",
+		"url": "/pledge/ships/argo/MPUV-Personnel",
+		"thumbnail": "/media/fgi7cen4bdvzkr/heap_infobox/Landing_v01.jpg"
+	},
+	{
+		"name": "MPUV Cargo",
+		"url": "/pledge/ships/argo/MPUV-Cargo",
+		"thumbnail": "/media/mywvchg9tot3xr/heap_infobox/BatCave_4k_v02.jpg"
+	},
+	{
+		"name": "Terrapin",
+		"url": "/pledge/ships/terrapin/Terrapin",
+		"thumbnail": "/media/ijkzkcb5t1w8zr/heap_infobox/Anvil_Terrapin_Piece_03_Surveilance_v3.jpg"
+	},
+	{
+		"name": "Polaris",
+		"url": "/pledge/ships/polaris/Polaris",
+		"thumbnail": "https://media.robertsspaceindustries.com/6dw8h0adz1y3s/heap_infobox.jpg"
+	},
+	{
+		"name": "Prowler",
+		"url": "/pledge/ships/prowler/Prowler",
+		"thumbnail": "/media/3j9cau4jygwier/heap_infobox/Esperia_Prowler_SHOT_01b.jpg"
+	},
+	{
+		"name": "85X",
+		"url": "/pledge/ships/85x/85X",
+		"thumbnail": "/media/4vht65hve2o1cr/heap_infobox/85_X_city_shot.jpg"
+	},
+	{
+		"name": "Razor",
+		"url": "/pledge/ships/razor/Razor",
+		"thumbnail": "https://media.robertsspaceindustries.com/wltzple6y1hy4/heap_infobox.jpg"
+	},
+	{
+		"name": "Razor EX",
+		"url": "/pledge/ships/razor/Razor-EX",
+		"thumbnail": "https://media.robertsspaceindustries.com/qn84a6os8q3db/heap_infobox.jpg"
+	},
+	{
+		"name": "Razor LX",
+		"url": "/pledge/ships/razor/Razor-LX",
+		"thumbnail": "https://media.robertsspaceindustries.com/xjp3pxmsvoxzb/heap_infobox.jpg"
+	},
+	{
+		"name": "Hurricane",
+		"url": "/pledge/ships/hurricane/Hurricane",
+		"thumbnail": "/media/iupif96slteo0r/heap_infobox/Action_02-Squashed.jpg"
+	},
+	{
+		"name": "Banu Defender",
+		"url": "/pledge/ships/defender/Banu-Defender",
+		"thumbnail": "https://media.robertsspaceindustries.com/nnb2oofnrlni9/heap_infobox.jpg"
+	},
+	{
+		"name": "Eclipse",
+		"url": "/pledge/ships/eclipse/Eclipse",
+		"thumbnail": "/media/uqceivqlombzor/heap_infobox/Aegis-Eclipse-L4-Piece-2-Hangar-Presentation-007.jpg"
+	},
+	{
+		"name": "Nox",
+		"url": "/pledge/ships/nox/Nox",
+		"thumbnail": "https://media.robertsspaceindustries.com/8v2mfqoya3hnc/heap_infobox.jpg"
+	},
+	{
+		"name": "Nox Kue",
+		"url": "/pledge/ships/nox/Nox-Kue",
+		"thumbnail": "https://media.robertsspaceindustries.com/qtdco5ba9acbc/heap_infobox.jpg"
+	},
+	{
+		"name": "Cyclone",
+		"url": "/pledge/ships/cyclone/Cyclone",
+		"thumbnail": "/media/ao2p3pw2e7k94r/heap_infobox/Tumbril-Buggy-Piece-01-Showroom-V009.jpg"
+	},
+	{
+		"name": "Cyclone-TR",
+		"url": "/pledge/ships/cyclone/Cyclone-TR",
+		"thumbnail": "/media/cmq3rwpo5ghpvr/heap_infobox/Tumbril-Buggy-Piece-04-Desert-V012.jpg"
+	},
+	{
+		"name": "Cyclone-RC",
+		"url": "/pledge/ships/cyclone/Cyclone-RC",
+		"thumbnail": "/media/w3vw5498xb25mr/heap_infobox/Tumbril-Buggy-Piece-05-Rocky-Beach-Sport-Fin.jpg"
+	},
+	{
+		"name": "Cyclone-RN",
+		"url": "/pledge/ships/cyclone/Cyclone-RN",
+		"thumbnail": "/media/vj0pi3ibl7k4zr/heap_infobox/Tumbril-Buggy-Piece-07-Black-Beach-V012a.jpg"
+	},
+	{
+		"name": "Cyclone-AA",
+		"url": "/pledge/ships/cyclone/Cyclone-AA",
+		"thumbnail": "/media/n6535dpiwv2pgr/heap_infobox/Tumbril-Buggy-Piece-06-Lagoon-V011.jpg"
+	},
+	{
+		"name": "Ursa Rover",
+		"url": "/pledge/ships/ursa/Ursa-Rover",
+		"thumbnail": "https://media.robertsspaceindustries.com/1pyqpmzccb5jq/heap_infobox.jpg"
+	},
+	{
+		"name": "Ursa Rover Fortuna",
+		"url": "/pledge/ships/ursa/Ursa-Rover-Fortuna",
+		"thumbnail": "https://media.robertsspaceindustries.com/g62q7c3956cu1/heap_infobox.jpg"
+	},
+	{
+		"name": "600i Touring",
+		"url": "/pledge/ships/600i/600i-Touring",
+		"thumbnail": "/media/z642zdp6d3mkzr/heap_infobox/600i-Touring.jpg"
+	},
+	{
+		"name": "600i Explorer",
+		"url": "/pledge/ships/600i/600i-Explorer",
+		"thumbnail": "https://media.robertsspaceindustries.com/n285kdnihheez/heap_infobox.jpg"
+	},
+	{
+		"name": "X1 Base",
+		"url": "/pledge/ships/x1/X1-Base",
+		"thumbnail": "/media/ktxtqr3rikt88r/heap_infobox/X1_base_white.png"
+	},
+	{
+		"name": "X1 Velocity",
+		"url": "/pledge/ships/x1/X1-Velocity",
+		"thumbnail": "https://media.robertsspaceindustries.com/1ddi6cnazo8bh/heap_infobox.png"
+	},
+	{
+		"name": "X1 Force",
+		"url": "/pledge/ships/x1/X1-Force",
+		"thumbnail": "https://media.robertsspaceindustries.com/b096uxlb9jvje/heap_infobox.png"
+	},
+	{
+		"name": "Pioneer",
+		"url": "/pledge/ships/pioneer/Pioneer",
+		"thumbnail": "/media/d1fv8alr2v0cgr/heap_infobox/Drydoc-4-Final.jpg"
+	},
+	{
+		"name": "Hawk",
+		"url": "/pledge/ships/hawk/Hawk",
+		"thumbnail": "/media/r48azchzf281xr/heap_infobox/Ah-Promo-Shot-01b.jpg"
+	},
+	{
+		"name": "Hammerhead",
+		"url": "/pledge/ships/hammerhead/Hammerhead",
+		"thumbnail": "https://media.robertsspaceindustries.com/93zcfnzsy6xnu/heap_infobox.png"
+	},
+	{
+		"name": "Hammerhead Best In Show Edition",
+		"url": "/pledge/ships/hammerhead/Hammerhead-Best-In-Show-Edition",
+		"thumbnail": "https://media.robertsspaceindustries.com/tmuyqtlpfh64d/heap_infobox.jpg"
+	},
+	{
+		"name": "Nova",
+		"url": "/pledge/ships/nova-tank/Nova",
+		"thumbnail": "/media/ul5zp2zllebm2r/heap_infobox/TMBL_HeavyTank_ShotG_PJ03-Squashed.jpg"
+	},
+	{
+		"name": "Vulcan",
+		"url": "/pledge/ships/vulcan/Vulcan",
+		"thumbnail": "https://media.robertsspaceindustries.com/6q50bb3oy5q8b/heap_infobox.jpg"
+	},
+	{
+		"name": "100i",
+		"url": "/pledge/ships/origin-100/100i",
+		"thumbnail": "https://media.robertsspaceindustries.com/ntdv7khpw1hpz/heap_infobox.jpg"
+	},
+	{
+		"name": "125a",
+		"url": "/pledge/ships/origin-100/125a",
+		"thumbnail": "https://media.robertsspaceindustries.com/5nerri3qlhrxc/heap_infobox.jpg"
+	},
+	{
+		"name": "135c",
+		"url": "/pledge/ships/origin-100/135c",
+		"thumbnail": "https://media.robertsspaceindustries.com/nm7aeugyam4v4/heap_infobox.jpg"
+	},
+	{
+		"name": "C2 Hercules",
+		"url": "/pledge/ships/crusader-starlifter/C2-Hercules",
+		"thumbnail": "/media/7bdt759toqnvhr/heap_infobox/CRUS_Starlifter_Promo_Basic_Landed_MO01-Squashed.jpg"
+	},
+	{
+		"name": "M2 Hercules",
+		"url": "/pledge/ships/crusader-starlifter/M2-Hercules",
+		"thumbnail": "/media/p077b9nm14i11r/heap_infobox/CRUS_Starlifter_Promo_Military_Flares_MO01-Squashed.jpg"
+	},
+	{
+		"name": "A2 Hercules",
+		"url": "/pledge/ships/crusader-starlifter/A2-Hercules",
+		"thumbnail": "/media/kct1e9vkx4ld6r/heap_infobox/CRUS_Starlifter_Promo_Gunship_Bombing_MO02-Squashed.jpg"
+	},
+	{
+		"name": "Vulture",
+		"url": "/pledge/ships/drake-vulture/Vulture",
+		"thumbnail": "https://media.robertsspaceindustries.com/whe7eao2yqmjm/heap_infobox.jpg"
+	},
+	{
+		"name": "Apollo Triage",
+		"url": "/pledge/ships/rsi-apollo/Apollo-Triage",
+		"thumbnail": "/media/63a4wxazxdzlir/heap_infobox/RSI_Apollo_SalesIcons_Red_PJ01-Squashed.jpg"
+	},
+	{
+		"name": "Apollo Medivac",
+		"url": "/pledge/ships/rsi-apollo/Apollo-Medivac",
+		"thumbnail": "https://media.robertsspaceindustries.com/an87zna125f7d/heap_infobox.jpg"
+	},
+	{
+		"name": "Mercury Star Runner",
+		"url": "/pledge/ships/crusader-mercury-star-runner/Mercury-Star-Runner",
+		"thumbnail": "/media/1fv0hyr8qml6vr/heap_infobox/Crusader-Starrunner-Birds-Eye-Min-1.jpeg"
+	},
+	{
+		"name": "Valkyrie",
+		"url": "/pledge/ships/anvil-valkyrie/Valkyrie",
+		"thumbnail": "https://media.robertsspaceindustries.com/9ypuudni1cbl6/heap_infobox.jpg"
+	},
+	{
+		"name": "Valkyrie Liberator Edition",
+		"url": "/pledge/ships/anvil-valkyrie/Valkyrie-Liberator-Edition",
+		"thumbnail": "/media/l87lynolh4pxyr/heap_infobox/128934g7tt.jpg"
+	},
+	{
+		"name": "Kraken",
+		"url": "/pledge/ships/drake-kraken/Kraken",
+		"thumbnail": "https://media.robertsspaceindustries.com/39mq5sef3eek2/heap_infobox.jpg"
+	},
+	{
+		"name": "Kraken Privateer",
+		"url": "/pledge/ships/drake-kraken/Kraken-Privateer",
+		"thumbnail": "https://media.robertsspaceindustries.com/nnu9953me3vod/heap_infobox.jpg"
+	},
+	{
+		"name": "Arrow",
+		"url": "/pledge/ships/anvil-arrow/Arrow",
+		"thumbnail": "https://media.robertsspaceindustries.com/th8oqphlhb0bk/heap_infobox.jpg"
+	},
+	{
+		"name": "San'tok.yāi",
+		"url": "/pledge/ships/aopoa-santokyai/Santoky-i",
+		"thumbnail": "https://media.robertsspaceindustries.com/tpjsembbxiikh/heap_infobox.jpg"
+	},
+	{
+		"name": "SRV",
+		"url": "/pledge/ships/argo-srv/SRV",
+		"thumbnail": "https://media.robertsspaceindustries.com/aojn1qvitpt1s/heap_infobox.jpg"
+	},
+	{
+		"name": "Corsair",
+		"url": "/pledge/ships/drake-corsair/Corsair",
+		"thumbnail": "https://media.robertsspaceindustries.com/2xatcl9uglt91/heap_infobox.jpg"
+	},
+	{
+		"name": "Ranger RC",
+		"url": "/pledge/ships/tumbril-ranger/Ranger-RC",
+		"thumbnail": "https://media.robertsspaceindustries.com/dwmsr86x3doif/heap_infobox.jpg"
+	},
+	{
+		"name": "Ranger TR",
+		"url": "/pledge/ships/tumbril-ranger/Ranger-TR",
+		"thumbnail": "https://media.robertsspaceindustries.com/5bcok11mha9hp/heap_infobox.jpg"
+	},
+	{
+		"name": "Ranger CV",
+		"url": "/pledge/ships/tumbril-ranger/Ranger-CV",
+		"thumbnail": "/media/a9ukhl4werezmr/heap_infobox/Cargo-Min.jpg"
+	},
+	{
+		"name": "Anvil Ballista ",
+		"url": "/pledge/ships/anvil-ballista/Anvil-Ballista",
+		"thumbnail": "https://media.robertsspaceindustries.com/y3adiaqxq3v9e/heap_infobox.jpg"
+	},
+	{
+		"name": "Anvil Ballista Snowblind",
+		"url": "/pledge/ships/anvil-ballista/Anvil-Ballista-Snowblind",
+		"thumbnail": "/media/a5nzp9tgvq2i5r/heap_infobox/Ballista_Snowblind-Min.jpg"
+	},
+	{
+		"name": "Anvil Ballista Dunestalker",
+		"url": "/pledge/ships/anvil-ballista/Anvil-Ballista-Dunestalker",
+		"thumbnail": "/media/rjxw89rs3sk5wr/heap_infobox/Ballista_Dunestalker-Min.jpg"
+	},
+	{
+		"name": "Nautilus ",
+		"url": "/pledge/ships/aegis-nautilus/Nautilus",
+		"thumbnail": "https://media.robertsspaceindustries.com/c6t6mr400hgx6/heap_infobox.jpg"
+	},
+	{
+		"name": "Nautilus Solstice Edition",
+		"url": "/pledge/ships/aegis-nautilus/Nautilus-Solstice-Edition",
+		"thumbnail": "https://media.robertsspaceindustries.com/mp9p2pzrvdxw9/heap_infobox.jpg"
+	},
+	{
+		"name": "Mantis",
+		"url": "/pledge/ships/rsi-mantis/Mantis",
+		"thumbnail": "https://media.robertsspaceindustries.com/srd2tmizujvbo/heap_infobox.jpg"
+	},
+	{
+		"name": "C8 Pisces",
+		"url": "/pledge/ships/anvil-pisces/C8-Pisces",
+		"thumbnail": "https://media.robertsspaceindustries.com/9y6uxd82fw0ne/heap_infobox.jpg"
+	},
+	{
+		"name": "C8X Pisces Expedition ",
+		"url": "/pledge/ships/anvil-pisces/C8X-Pisces-Expedition",
+		"thumbnail": "https://media.robertsspaceindustries.com/kj7oh12zn2f1l/heap_infobox.jpg"
+	},
+	{
+		"name": "Crusader Ares Inferno ",
+		"url": "/pledge/ships/crusader-ares/Crusader-Ares-Inferno",
+		"thumbnail": "https://media.robertsspaceindustries.com/hg5k6498yhyzp/heap_infobox.jpg"
+	},
+	{
+		"name": "Crusader Ares Ion",
+		"url": "/pledge/ships/crusader-ares/Crusader-Ares-Ion",
+		"thumbnail": "https://media.robertsspaceindustries.com/820xdzlyfr9lg/heap_infobox.jpg"
+	},
+	{
+		"name": "Argo Mole",
+		"url": "/pledge/ships/argo-mole/Argo-Mole",
+		"thumbnail": "/media/oyl9g7aqg17smr/heap_infobox/ARGO_Mole_Space_122019.jpg"
+	},
+	{
+		"name": "Argo Mole Carbon Edition",
+		"url": "/pledge/ships/argo-mole/Argo-Mole-Carbon-Edition",
+		"thumbnail": "https://media.robertsspaceindustries.com/ugpy6i9pbgbax/heap_infobox.jpg"
+	},
+	{
+		"name": "Argo Mole Talus Edition",
+		"url": "/pledge/ships/argo-mole/Argo-Mole-Talus-Edition",
+		"thumbnail": "https://media.robertsspaceindustries.com/ghac95q2ncobp/heap_infobox.jpg"
+	},
+	{
+		"name": "Origin G12",
+		"url": "/pledge/ships/origin-g12/Origin-G12",
+		"thumbnail": "https://media.robertsspaceindustries.com/brmi1ci9rthmu/heap_infobox.jpg"
+	},
+	{
+		"name": "Origin G12r",
+		"url": "/pledge/ships/origin-g12/Origin-G12r",
+		"thumbnail": "https://media.robertsspaceindustries.com/ou0nkzhocb2bd/heap_infobox.jpg"
+	},
+	{
+		"name": "Origin G12a",
+		"url": "/pledge/ships/origin-g12/Origin-G12a",
+		"thumbnail": "https://media.robertsspaceindustries.com/2btmuamt8zv4g/heap_infobox.jpg"
+	},
+	{
+		"name": "Esperia Talon",
+		"url": "/pledge/ships/talon/Esperia-Talon",
+		"thumbnail": "https://media.robertsspaceindustries.com/e92yq6jha5uzs/heap_infobox.jpg"
+	},
+	{
+		"name": "Esperia Talon Shrike",
+		"url": "/pledge/ships/talon/Esperia-Talon-Shrike",
+		"thumbnail": "https://media.robertsspaceindustries.com/3gsfs0i1etq71/heap_infobox.jpg"
+	},
+	{
+		"name": "ROC",
+		"url": "/pledge/ships/roc/ROC",
+		"thumbnail": "https://media.robertsspaceindustries.com/wo06flt432pjs/heap_infobox.jpg"
+	},
+	{
+		"name": "CNOU Nomad",
+		"url": "/pledge/ships/nomad/CNOU-Nomad",
+		"thumbnail": "https://media.robertsspaceindustries.com/fcqc4k2uwgpbr/heap_infobox.jpg"
+	},
+	{
+		"name": "RSI Perseus",
+		"url": "/pledge/ships/perseus/RSI-Perseus",
+		"thumbnail": "https://media.robertsspaceindustries.com/wzzgz1hzpl4bs/heap_infobox.jpg"
+	}
 ]

--- a/src/web_resources/HangarXPLOR.Ships.js
+++ b/src/web_resources/HangarXPLOR.Ships.js
@@ -4,102 +4,122 @@ HangarXPLOR._ships = [
 	{
 		"name": "Aurora ES",
 		"url": "/pledge/ships/rsi-aurora/Aurora-ES",
-		"thumbnail": "https://media.robertsspaceindustries.com/pnxa8gu3m0wut/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/pnxa8gu3m0wut/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/aurora-es"
 	},
 	{
 		"name": "Aurora LX",
 		"url": "/pledge/ships/rsi-aurora/Aurora-LX",
-		"thumbnail": "https://media.robertsspaceindustries.com/n08kif9wp2t94/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/n08kif9wp2t94/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/aurora-lx"
 	},
 	{
 		"name": "Aurora MR",
 		"url": "/pledge/ships/rsi-aurora/Aurora-MR",
-		"thumbnail": "https://media.robertsspaceindustries.com/7zbk19qeqy9fp/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/7zbk19qeqy9fp/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/aurora-mr"
 	},
 	{
 		"name": "Aurora CL",
 		"url": "/pledge/ships/rsi-aurora/Aurora-CL",
-		"thumbnail": "https://media.robertsspaceindustries.com/eqexi7735yer1/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/eqexi7735yer1/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/aurora-cl"
 	},
 	{
 		"name": "Aurora LN",
 		"url": "/pledge/ships/rsi-aurora/Aurora-LN",
-		"thumbnail": "https://media.robertsspaceindustries.com/0ufx8v9k7kult/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/0ufx8v9k7kult/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/aurora-ln"
 	},
 	{
 		"name": "300i",
 		"url": "/pledge/ships/origin-300/300i",
-		"thumbnail": "https://media.robertsspaceindustries.com/q5d6d32fzus8s/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/q5d6d32fzus8s/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/300i"
 	},
 	{
 		"name": "315p",
 		"url": "/pledge/ships/origin-300/315p",
-		"thumbnail": "https://media.robertsspaceindustries.com/zd6vxsvdq0gxp/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/zd6vxsvdq0gxp/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/315p"
 	},
 	{
 		"name": "325a",
 		"url": "/pledge/ships/origin-300/325a",
-		"thumbnail": "https://media.robertsspaceindustries.com/eesg17ack8awh/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/eesg17ack8awh/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/325a"
 	},
 	{
 		"name": "350r",
 		"url": "/pledge/ships/origin-300/350r",
-		"thumbnail": "https://media.robertsspaceindustries.com/7mk0roegof8jp/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/7mk0roegof8jp/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/350r"
 	},
 	{
 		"name": "F7C Hornet",
 		"url": "/pledge/ships/anvil-hornet/F7C-Hornet",
-		"thumbnail": "https://media.robertsspaceindustries.com/tcpakf2m1h1hx/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/tcpakf2m1h1hx/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/f7c-hornet"
 	},
 	{
 		"name": "F7C Hornet Wildfire",
 		"url": "/pledge/ships/anvil-hornet/F7C-Hornet-Wildfire",
-		"thumbnail": "/media/0ioeh7g90gnqsr/heap_infobox/Wildfire_render1.jpg"
+		"thumbnail": "/media/0ioeh7g90gnqsr/heap_infobox/Wildfire_render1.jpg",
+		"fleetyard": "https://fleetyards.net/ships/f7c-hornet-wildfire"
 	},
 	{
 		"name": "F7C-S Hornet Ghost",
 		"url": "/pledge/ships/anvil-hornet/F7C-S-Hornet-Ghost",
-		"thumbnail": "https://media.robertsspaceindustries.com/nbwncbo1436rs/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/nbwncbo1436rs/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/f7c-s-hornet-ghost"
 	},
 	{
 		"name": "F7C-R Hornet Tracker",
 		"url": "/pledge/ships/anvil-hornet/F7C-R-Hornet-Tracker",
-		"thumbnail": "https://media.robertsspaceindustries.com/biy2mmvcz6eb2/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/biy2mmvcz6eb2/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/f7c-r-hornet-tracker"
 	},
 	{
 		"name": "F7C-M Super Hornet",
 		"url": "/pledge/ships/anvil-hornet/F7C-M-Super-Hornet",
-		"thumbnail": "https://media.robertsspaceindustries.com/pjudaw3yj3odo/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/pjudaw3yj3odo/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/f7c-m-super-hornet"
 	},
 	{
 		"name": "F7A Hornet",
 		"url": "/pledge/ships/anvil-hornet/F7A-Hornet",
-		"thumbnail": "/media/j2ie1gy9x9zsbr/heap_infobox/F7a.jpg"
+		"thumbnail": "/media/j2ie1gy9x9zsbr/heap_infobox/F7a.jpg",
+		"fleetyard": "https://fleetyards.net/ships/f7a-hornet"
 	},
 	{
 		"name": "F7C-M Super Hornet Heartseeker",
 		"url": "/pledge/ships/anvil-hornet/F7C-M-Super-Hornet-Heartseeker",
-		"thumbnail": "https://media.robertsspaceindustries.com/6ewzke6o3llh6/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/6ewzke6o3llh6/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/f7c-m-super-hornet-heartseeker"
 	},
 	{
 		"name": "Constellation Aquila",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Aquila",
-		"thumbnail": "https://media.robertsspaceindustries.com/c2k21tjgn3z6a/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/c2k21tjgn3z6a/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/constellation-aquila"
 	},
 	{
 		"name": "Constellation Andromeda",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Andromeda",
-		"thumbnail": "https://media.robertsspaceindustries.com/b5wlk3qo9v3iq/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/b5wlk3qo9v3iq/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/constellation-andromeda"
 	},
 	{
 		"name": "Constellation Taurus",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Taurus",
-		"thumbnail": "/media/3vj4o4l5uggk7r/heap_infobox/Taurus-Storefront.jpg"
+		"thumbnail": "/media/3vj4o4l5uggk7r/heap_infobox/Taurus-Storefront.jpg",
+		"fleetyard": "https://fleetyards.net/ships/constellation-taurus"
 	},
 	{
 		"name": "Constellation Phoenix",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Phoenix",
-		"thumbnail": "https://media.robertsspaceindustries.com/jkyny550a90um/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/jkyny550a90um/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/constellation-phoenix"
 	},
 	{
 		"name": "Constellation Phoenix Emerald",
@@ -109,37 +129,44 @@ HangarXPLOR._ships = [
 	{
 		"name": "Freelancer",
 		"url": "/pledge/ships/misc-freelancer/Freelancer",
-		"thumbnail": "https://media.robertsspaceindustries.com/z3mllk6zi0x7r/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/z3mllk6zi0x7r/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/freelancer"
 	},
 	{
 		"name": "Freelancer DUR",
 		"url": "/pledge/ships/misc-freelancer/Freelancer-DUR",
-		"thumbnail": "https://media.robertsspaceindustries.com/d5tl8fqymjuf7/heap_infobox.png"
+		"thumbnail": "https://media.robertsspaceindustries.com/d5tl8fqymjuf7/heap_infobox.png",
+		"fleetyard": "https://fleetyards.net/ships/freelancer-dur"
 	},
 	{
 		"name": "Freelancer MAX",
 		"url": "/pledge/ships/misc-freelancer/Freelancer-MAX",
-		"thumbnail": "https://media.robertsspaceindustries.com/tllo2q10dvzmi/heap_infobox.png"
+		"thumbnail": "https://media.robertsspaceindustries.com/tllo2q10dvzmi/heap_infobox.png",
+		"fleetyard": "https://fleetyards.net/ships/freelancer-max"
 	},
 	{
 		"name": "Freelancer MIS",
 		"url": "/pledge/ships/misc-freelancer/Freelancer-MIS",
-		"thumbnail": "https://media.robertsspaceindustries.com/ybkygputhkx0g/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/ybkygputhkx0g/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/freelancer-mis"
 	},
 	{
 		"name": "Cutlass Black",
 		"url": "/pledge/ships/drake-cutlass/Cutlass-Black",
-		"thumbnail": "https://media.robertsspaceindustries.com/wj92rqzvhnecb/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/wj92rqzvhnecb/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/cutlass-black"
 	},
 	{
 		"name": "Cutlass Red",
 		"url": "/pledge/ships/drake-cutlass/Cutlass-Red",
-		"thumbnail": "https://media.robertsspaceindustries.com/c93bnty7qmhzb/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/c93bnty7qmhzb/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/cutlass-red"
 	},
 	{
 		"name": "Cutlass Blue",
 		"url": "/pledge/ships/drake-cutlass/Cutlass-Blue",
-		"thumbnail": "https://media.robertsspaceindustries.com/r7z7uznkhwojt/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/r7z7uznkhwojt/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/cutlass-blue"
 	},
 	{
 		"name": "Cutlass Black Best In Show Edition",
@@ -149,47 +176,56 @@ HangarXPLOR._ships = [
 	{
 		"name": "Avenger Stalker",
 		"url": "/pledge/ships/aegis-avenger/Avenger-Stalker",
-		"thumbnail": "https://media.robertsspaceindustries.com/9tfhza1twrczn/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/9tfhza1twrczn/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/avenger-stalker"
 	},
 	{
 		"name": "Avenger Titan Renegade",
 		"url": "/pledge/ships/aegis-avenger/Avenger-Titan-Renegade",
-		"thumbnail": "https://media.robertsspaceindustries.com/oc8p2v3n7c0e0/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/oc8p2v3n7c0e0/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/avenger-titan-renegade"
 	},
 	{
 		"name": "Avenger Warlock",
 		"url": "/pledge/ships/aegis-avenger/Avenger-Warlock",
-		"thumbnail": "https://media.robertsspaceindustries.com/l8znbwwoh2o8u/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/l8znbwwoh2o8u/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/avenger-warlock"
 	},
 	{
 		"name": "Avenger Titan",
 		"url": "/pledge/ships/aegis-avenger/Avenger-Titan",
-		"thumbnail": "https://media.robertsspaceindustries.com/fmhdkmvhi8ify/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/fmhdkmvhi8ify/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/avenger-titan"
 	},
 	{
 		"name": "Gladiator",
 		"url": "/pledge/ships/anvil-gladiator/Gladiator",
-		"thumbnail": "/media/ye6hvyo93oc2ar/heap_infobox/Gladiator-WB_FrontLeft.jpg"
+		"thumbnail": "/media/ye6hvyo93oc2ar/heap_infobox/Gladiator-WB_FrontLeft.jpg",
+		"fleetyard": "https://fleetyards.net/ships/gladiator"
 	},
 	{
 		"name": "M50",
 		"url": "/pledge/ships/origin-m50/M50",
-		"thumbnail": "https://media.robertsspaceindustries.com/rdj7iilxxhvet/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/rdj7iilxxhvet/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/m50"
 	},
 	{
 		"name": "Starfarer",
 		"url": "/pledge/ships/misc-starfarer/Starfarer",
-		"thumbnail": "https://media.robertsspaceindustries.com/5ukbyxyx8t6ek/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/5ukbyxyx8t6ek/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/starfarer"
 	},
 	{
 		"name": "Starfarer Gemini",
 		"url": "/pledge/ships/misc-starfarer/Starfarer-Gemini",
-		"thumbnail": "https://media.robertsspaceindustries.com/c6423etmvm52z/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/c6423etmvm52z/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/starfarer-gemini"
 	},
 	{
 		"name": "Caterpillar",
 		"url": "/pledge/ships/drake-caterpillar/Caterpillar",
-		"thumbnail": "https://media.robertsspaceindustries.com/d2lkocbd58mvc/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/d2lkocbd58mvc/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/caterpillar"
 	},
 	{
 		"name": "Caterpillar Pirate Edition",
@@ -204,57 +240,68 @@ HangarXPLOR._ships = [
 	{
 		"name": "Retaliator Bomber",
 		"url": "/pledge/ships/aegis-retaliator/Retaliator-Bomber",
-		"thumbnail": "/media/kz6mu0tt0u06er/heap_infobox/Retaliator-Ortho_v2.jpg"
+		"thumbnail": "/media/kz6mu0tt0u06er/heap_infobox/Retaliator-Ortho_v2.jpg",
+		"fleetyard": "https://fleetyards.net/ships/retaliator-bomber"
 	},
 	{
 		"name": "Retaliator Base",
 		"url": "/pledge/ships/aegis-retaliator/Retaliator-Base",
-		"thumbnail": "https://media.robertsspaceindustries.com/sa6wyt4so2dtk/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/sa6wyt4so2dtk/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/retaliator-base"
 	},
 	{
 		"name": "Scythe",
 		"url": "/pledge/ships/scythe/Scythe",
-		"thumbnail": "/media/wdtdkzl0x31ver/heap_infobox/Vanduul-Scythe_storefront_visual.jpg"
+		"thumbnail": "/media/wdtdkzl0x31ver/heap_infobox/Vanduul-Scythe_storefront_visual.jpg",
+		"fleetyard": "https://fleetyards.net/ships/scythe"
 	},
 	{
 		"name": "Idris-M",
 		"url": "/pledge/ships/aegis-idris/Idris-M",
-		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg"
+		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg",
+		"fleetyard": "https://fleetyards.net/ships/idris-m"
 	},
 	{
 		"name": "Idris-P",
 		"url": "/pledge/ships/aegis-idris/Idris-P",
-		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg"
+		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg",
+		"fleetyard": "https://fleetyards.net/ships/idris-p"
 	},
 	{
 		"name": "P-52 Merlin",
 		"url": "/pledge/ships/p52-merlin/P-52-Merlin",
-		"thumbnail": "/media/a9231ysz5cnvor/heap_infobox/Top.jpg"
+		"thumbnail": "/media/a9231ysz5cnvor/heap_infobox/Top.jpg",
+		"fleetyard": "https://fleetyards.net/ships/p-52-merlin"
 	},
 	{
 		"name": "Mustang Alpha",
 		"url": "/pledge/ships/mustang/Mustang-Alpha",
-		"thumbnail": "/media/cpq6ly29wmi1br/heap_infobox/56745675467.jpg"
+		"thumbnail": "/media/cpq6ly29wmi1br/heap_infobox/56745675467.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mustang-alpha"
 	},
 	{
 		"name": "Mustang Beta",
 		"url": "/pledge/ships/mustang/Mustang-Beta",
-		"thumbnail": "/media/4ws8rrspe10exr/heap_infobox/5675676578.jpg"
+		"thumbnail": "/media/4ws8rrspe10exr/heap_infobox/5675676578.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mustang-beta"
 	},
 	{
 		"name": "Mustang Gamma",
 		"url": "/pledge/ships/mustang/Mustang-Gamma",
-		"thumbnail": "/media/yu4cuzh90oz54r/heap_infobox/Gamma-Front.jpg"
+		"thumbnail": "/media/yu4cuzh90oz54r/heap_infobox/Gamma-Front.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mustang-gamma"
 	},
 	{
 		"name": "Mustang Delta",
 		"url": "/pledge/ships/mustang/Mustang-Delta",
-		"thumbnail": "https://media.robertsspaceindustries.com/s7ntca9x35tjl/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/s7ntca9x35tjl/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mustang-delta"
 	},
 	{
 		"name": "Mustang Omega",
 		"url": "/pledge/ships/mustang/Mustang-Omega",
-		"thumbnail": "/media/gmru9y7ynd1bbr/heap_infobox/Omega-Front.jpg"
+		"thumbnail": "/media/gmru9y7ynd1bbr/heap_infobox/Omega-Front.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mustang-omega"
 	},
 	{
 		"name": "Mustang Alpha Vindicator",
@@ -264,42 +311,50 @@ HangarXPLOR._ships = [
 	{
 		"name": "Redeemer",
 		"url": "/pledge/ships/redeemer/Redeemer",
-		"thumbnail": "/media/t0opqw0tauo45r/heap_infobox/Red1.jpg"
+		"thumbnail": "/media/t0opqw0tauo45r/heap_infobox/Red1.jpg",
+		"fleetyard": "https://fleetyards.net/ships/redeemer"
 	},
 	{
 		"name": "Gladius",
 		"url": "/pledge/ships/gladius/Gladius",
-		"thumbnail": "https://media.robertsspaceindustries.com/xxdvidtr1ze6b/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/xxdvidtr1ze6b/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/gladius"
 	},
 	{
 		"name": "Gladius Valiant",
 		"url": "/pledge/ships/gladius/Gladius-Valiant",
-		"thumbnail": "/media/mpszlemby5r43r/heap_infobox/Gladius_variant_sale_img.jpg"
+		"thumbnail": "/media/mpszlemby5r43r/heap_infobox/Gladius_variant_sale_img.jpg",
+		"fleetyard": "https://fleetyards.net/ships/gladius-valiant"
 	},
 	{
 		"name": "Pirate Gladius",
 		"url": "/pledge/ships/gladius/Pirate-Gladius",
-		"thumbnail": "https://media.robertsspaceindustries.com/9cwz2utclixvt/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/9cwz2utclixvt/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/pirate-gladius"
 	},
 	{
 		"name": "Khartu-Al",
 		"url": "/pledge/ships/khartu/Khartu-Al",
-		"thumbnail": "https://media.robertsspaceindustries.com/g8xkja21h9rep/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/g8xkja21h9rep/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/khartu-al"
 	},
 	{
 		"name": "Merchantman",
 		"url": "/pledge/ships/merchantman/Merchantman",
-		"thumbnail": "https://media.robertsspaceindustries.com/6z00b42zydbnm/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/6z00b42zydbnm/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/merchantman"
 	},
 	{
 		"name": "890 Jump",
 		"url": "/pledge/ships/890-jump/890-Jump",
-		"thumbnail": "https://media.robertsspaceindustries.com/t2bky2nbdg0ms/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/t2bky2nbdg0ms/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/890-jump"
 	},
 	{
 		"name": "Carrack",
 		"url": "/pledge/ships/carrack/Carrack",
-		"thumbnail": "/media/uacgp8oc20yekr/heap_infobox/Carrack.jpg"
+		"thumbnail": "/media/uacgp8oc20yekr/heap_infobox/Carrack.jpg",
+		"fleetyard": "https://fleetyards.net/ships/carrack"
 	},
 	{
 		"name": "Carrack w/C8X",
@@ -319,42 +374,50 @@ HangarXPLOR._ships = [
 	{
 		"name": "Herald",
 		"url": "/pledge/ships/herald/Herald",
-		"thumbnail": "https://media.robertsspaceindustries.com/xcbs8bs50xo23/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/xcbs8bs50xo23/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/herald"
 	},
 	{
 		"name": "Hull C",
 		"url": "/pledge/ships/hull/Hull-C",
-		"thumbnail": "/media/w54u21vkhci5vr/heap_infobox/Hull_C_Final.jpg"
+		"thumbnail": "/media/w54u21vkhci5vr/heap_infobox/Hull_C_Final.jpg",
+		"fleetyard": "https://fleetyards.net/ships/hull-c"
 	},
 	{
 		"name": "Hull A",
 		"url": "/pledge/ships/hull/Hull-A",
-		"thumbnail": "/media/tpw5r365mowmar/heap_infobox/Hull_A_Final.jpg"
+		"thumbnail": "/media/tpw5r365mowmar/heap_infobox/Hull_A_Final.jpg",
+		"fleetyard": "https://fleetyards.net/ships/hull-a"
 	},
 	{
 		"name": "Hull B",
 		"url": "/pledge/ships/hull/Hull-B",
-		"thumbnail": "/media/xg8d8kyo0bjsmr/heap_infobox/HullB_landedcompv3b.jpg"
+		"thumbnail": "/media/xg8d8kyo0bjsmr/heap_infobox/HullB_landedcompv3b.jpg",
+		"fleetyard": "https://fleetyards.net/ships/hull-b"
 	},
 	{
 		"name": "Hull D",
 		"url": "/pledge/ships/hull/Hull-D",
-		"thumbnail": "https://media.robertsspaceindustries.com/1j6650dnbblli/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/1j6650dnbblli/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/hull-d"
 	},
 	{
 		"name": "Hull E",
 		"url": "/pledge/ships/hull/Hull-E",
-		"thumbnail": "/media/xyt1qu08sjmy3r/heap_infobox/Hull_E_3_compflat.jpg"
+		"thumbnail": "/media/xyt1qu08sjmy3r/heap_infobox/Hull_E_3_compflat.jpg",
+		"fleetyard": "https://fleetyards.net/ships/hull-e"
 	},
 	{
 		"name": "Orion",
 		"url": "/pledge/ships/orion/Orion",
-		"thumbnail": "/media/hfpnkupg7gr6er/heap_infobox/RSI_Orion_Situ1b_150219_GH.jpg"
+		"thumbnail": "/media/hfpnkupg7gr6er/heap_infobox/RSI_Orion_Situ1b_150219_GH.jpg",
+		"fleetyard": "https://fleetyards.net/ships/orion"
 	},
 	{
 		"name": "Reclaimer",
 		"url": "/pledge/ships/reclaimer/Reclaimer",
-		"thumbnail": "https://media.robertsspaceindustries.com/iweivr5xyt5j1/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/iweivr5xyt5j1/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/reclaimer"
 	},
 	{
 		"name": "Reclaimer Best In Show Edition",
@@ -364,87 +427,104 @@ HangarXPLOR._ships = [
 	{
 		"name": "Javelin",
 		"url": "/pledge/ships/aegis-javelin/Javelin",
-		"thumbnail": "https://media.robertsspaceindustries.com/oc89p5ksizcla/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/oc89p5ksizcla/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/javelin"
 	},
 	{
 		"name": "Vanguard Warden",
 		"url": "/pledge/ships/vanguard/Vanguard-Warden",
-		"thumbnail": "https://media.robertsspaceindustries.com/sgzm3dw5q0o3y/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/sgzm3dw5q0o3y/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/vanguard-warden"
 	},
 	{
 		"name": "Vanguard Harbinger",
 		"url": "/pledge/ships/vanguard/Vanguard-Harbinger",
-		"thumbnail": "https://media.robertsspaceindustries.com/enygi6572pnkl/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/enygi6572pnkl/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/vanguard-harbinger"
 	},
 	{
 		"name": "Vanguard Sentinel",
 		"url": "/pledge/ships/vanguard/Vanguard-Sentinel",
-		"thumbnail": "https://media.robertsspaceindustries.com/4e4e30eyvq6d6/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/4e4e30eyvq6d6/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/vanguard-sentinel"
 	},
 	{
 		"name": "Vanguard Hoplite",
 		"url": "/pledge/ships/vanguard/Vanguard-Hoplite",
-		"thumbnail": "/media/zwyyyap3aa7wwr/heap_infobox/Aegis_Vanguard_Hoplite_01.jpg"
+		"thumbnail": "/media/zwyyyap3aa7wwr/heap_infobox/Aegis_Vanguard_Hoplite_01.jpg",
+		"fleetyard": "https://fleetyards.net/ships/vanguard-hoplite"
 	},
 	{
 		"name": "Reliant Kore",
 		"url": "/pledge/ships/reliant/Reliant-Kore",
-		"thumbnail": "https://media.robertsspaceindustries.com/hyi1vmyi6ppj6/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/hyi1vmyi6ppj6/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/reliant-kore"
 	},
 	{
 		"name": "Reliant Mako",
 		"url": "/pledge/ships/reliant/Reliant-Mako",
-		"thumbnail": "https://media.robertsspaceindustries.com/awmk2vgihtpf9/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/awmk2vgihtpf9/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/reliant-mako"
 	},
 	{
 		"name": "Reliant Sen",
 		"url": "/pledge/ships/reliant/Reliant-Sen",
-		"thumbnail": "https://media.robertsspaceindustries.com/8ewkdvinyoy4c/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/8ewkdvinyoy4c/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/reliant-sen"
 	},
 	{
 		"name": "Reliant Tana",
 		"url": "/pledge/ships/reliant/Reliant-Tana",
-		"thumbnail": "https://media.robertsspaceindustries.com/qe3ifzhvxdcww/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/qe3ifzhvxdcww/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/reliant-tana"
 	},
 	{
 		"name": "Genesis Starliner",
 		"url": "/pledge/ships/starliner/Genesis-Starliner",
-		"thumbnail": "/media/iqk7vt4xay0zfr/heap_infobox/Starliner_action1_runwaycompFlat.jpg"
+		"thumbnail": "/media/iqk7vt4xay0zfr/heap_infobox/Starliner_action1_runwaycompFlat.jpg",
+		"fleetyard": "https://fleetyards.net/ships/genesis-starliner"
 	},
 	{
 		"name": "Glaive",
 		"url": "/pledge/ships/esperia-glaive/Glaive",
-		"thumbnail": "https://media.robertsspaceindustries.com/gk4dk2ip4w1ia/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/gk4dk2ip4w1ia/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/glaive"
 	},
 	{
 		"name": "Endeavor",
 		"url": "/pledge/ships/misc-endeavor/Endeavor",
-		"thumbnail": "/media/vh2jbjaom7ys4r/heap_infobox/CO_Beauty_BioDomes.jpg"
+		"thumbnail": "/media/vh2jbjaom7ys4r/heap_infobox/CO_Beauty_BioDomes.jpg",
+		"fleetyard": "https://fleetyards.net/ships/endeavor"
 	},
 	{
 		"name": "Sabre",
 		"url": "/pledge/ships/sabre/Sabre",
-		"thumbnail": "https://media.robertsspaceindustries.com/p32tq6jjp301r/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/p32tq6jjp301r/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/sabre"
 	},
 	{
 		"name": "Sabre Comet",
 		"url": "/pledge/ships/sabre/Sabre-Comet",
-		"thumbnail": "/media/8pmglyd0scvhar/heap_infobox/Sabre_variant_sale_img.jpg"
+		"thumbnail": "/media/8pmglyd0scvhar/heap_infobox/Sabre_variant_sale_img.jpg",
+		"fleetyard": "https://fleetyards.net/ships/sabre-comet"
 	},
 	{
 		"name": "Sabre Raven",
 		"url": "/pledge/ships/sabre/Sabre-Raven",
-		"thumbnail": "/media/3q1dirw16ezv5r/heap_infobox/3_4_front_raven_blue_Enlarge_Crop.jpg"
+		"thumbnail": "/media/3q1dirw16ezv5r/heap_infobox/3_4_front_raven_blue_Enlarge_Crop.jpg",
+		"fleetyard": "https://fleetyards.net/ships/sabre-raven"
 	},
 	{
 		"name": "Crucible",
 		"url": "/pledge/ships/crucible/Crucible",
-		"thumbnail": "https://media.robertsspaceindustries.com/q81gvelwf2usv/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/q81gvelwf2usv/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/crucible"
 	},
 	{
 		"name": "P72 Archimedes",
 		"url": "/pledge/ships/p72-archimedes/P72-Archimedes",
-		"thumbnail": "/media/xqgbgw3x6o54ir/heap_infobox/Archimedes_Front_01.jpg"
+		"thumbnail": "/media/xqgbgw3x6o54ir/heap_infobox/Archimedes_Front_01.jpg",
+		"fleetyard": "https://fleetyards.net/ships/p-72-archimedes"
 	},
 	{
 		"name": "P72 Archimedes Emerald",
@@ -454,172 +534,206 @@ HangarXPLOR._ships = [
 	{
 		"name": "Blade",
 		"url": "/pledge/ships/vanduul-blade/Blade",
-		"thumbnail": "https://media.robertsspaceindustries.com/hyp6k1cu5qh8a/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/hyp6k1cu5qh8a/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/blade"
 	},
 	{
 		"name": "Prospector",
 		"url": "/pledge/ships/misc-prospector/Prospector",
-		"thumbnail": "https://media.robertsspaceindustries.com/bsrfd5pqb769v/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/bsrfd5pqb769v/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/prospector"
 	},
 	{
 		"name": "Buccaneer",
 		"url": "/pledge/ships/drake-buccaneer/Buccaneer",
-		"thumbnail": "/media/eiua12z9nxlkar/heap_infobox/Buc_final120_compFlat.jpg"
+		"thumbnail": "/media/eiua12z9nxlkar/heap_infobox/Buc_final120_compFlat.jpg",
+		"fleetyard": "https://fleetyards.net/ships/buccaneer"
 	},
 	{
 		"name": "Dragonfly Yellowjacket",
 		"url": "/pledge/ships/drake-dragonfly/Dragonfly-Yellowjacket",
-		"thumbnail": "/media/am12jusvbx8mqr/heap_infobox/Dragonfly-Left.jpg"
+		"thumbnail": "/media/am12jusvbx8mqr/heap_infobox/Dragonfly-Left.jpg",
+		"fleetyard": "https://fleetyards.net/ships/dragonfly-yellowjacket"
 	},
 	{
 		"name": "Dragonfly Black",
 		"url": "/pledge/ships/drake-dragonfly/Dragonfly-Black",
-		"thumbnail": "/media/5v25a4lwtbdlar/heap_infobox/Dragonfly-Black-Left.jpg"
+		"thumbnail": "/media/5v25a4lwtbdlar/heap_infobox/Dragonfly-Black-Left.jpg",
+		"fleetyard": "https://fleetyards.net/ships/dragonfly-black"
 	},
 	{
 		"name": "MPUV Personnel",
 		"url": "/pledge/ships/argo/MPUV-Personnel",
-		"thumbnail": "/media/fgi7cen4bdvzkr/heap_infobox/Landing_v01.jpg"
+		"thumbnail": "/media/fgi7cen4bdvzkr/heap_infobox/Landing_v01.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mpuv-personnel"
 	},
 	{
 		"name": "MPUV Cargo",
 		"url": "/pledge/ships/argo/MPUV-Cargo",
-		"thumbnail": "/media/mywvchg9tot3xr/heap_infobox/BatCave_4k_v02.jpg"
+		"thumbnail": "/media/mywvchg9tot3xr/heap_infobox/BatCave_4k_v02.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mpuv-cargo"
 	},
 	{
 		"name": "Terrapin",
 		"url": "/pledge/ships/terrapin/Terrapin",
-		"thumbnail": "/media/ijkzkcb5t1w8zr/heap_infobox/Anvil_Terrapin_Piece_03_Surveilance_v3.jpg"
+		"thumbnail": "/media/ijkzkcb5t1w8zr/heap_infobox/Anvil_Terrapin_Piece_03_Surveilance_v3.jpg",
+		"fleetyard": "https://fleetyards.net/ships/terrapin"
 	},
 	{
 		"name": "Polaris",
 		"url": "/pledge/ships/polaris/Polaris",
-		"thumbnail": "https://media.robertsspaceindustries.com/6dw8h0adz1y3s/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/6dw8h0adz1y3s/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/polaris"
 	},
 	{
 		"name": "Prowler",
 		"url": "/pledge/ships/prowler/Prowler",
-		"thumbnail": "/media/3j9cau4jygwier/heap_infobox/Esperia_Prowler_SHOT_01b.jpg"
+		"thumbnail": "/media/3j9cau4jygwier/heap_infobox/Esperia_Prowler_SHOT_01b.jpg",
+		"fleetyard": "https://fleetyards.net/ships/prowler"
 	},
 	{
 		"name": "85X",
 		"url": "/pledge/ships/85x/85X",
-		"thumbnail": "/media/4vht65hve2o1cr/heap_infobox/85_X_city_shot.jpg"
+		"thumbnail": "/media/4vht65hve2o1cr/heap_infobox/85_X_city_shot.jpg",
+		"fleetyard": "https://fleetyards.net/ships/85x"
 	},
 	{
 		"name": "Razor",
 		"url": "/pledge/ships/razor/Razor",
-		"thumbnail": "https://media.robertsspaceindustries.com/wltzple6y1hy4/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/wltzple6y1hy4/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/razor"
 	},
 	{
 		"name": "Razor EX",
 		"url": "/pledge/ships/razor/Razor-EX",
-		"thumbnail": "https://media.robertsspaceindustries.com/qn84a6os8q3db/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/qn84a6os8q3db/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/razor-ex"
 	},
 	{
 		"name": "Razor LX",
 		"url": "/pledge/ships/razor/Razor-LX",
-		"thumbnail": "https://media.robertsspaceindustries.com/xjp3pxmsvoxzb/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/xjp3pxmsvoxzb/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/razor-lx"
 	},
 	{
 		"name": "Hurricane",
 		"url": "/pledge/ships/hurricane/Hurricane",
-		"thumbnail": "/media/iupif96slteo0r/heap_infobox/Action_02-Squashed.jpg"
+		"thumbnail": "/media/iupif96slteo0r/heap_infobox/Action_02-Squashed.jpg",
+		"fleetyard": "https://fleetyards.net/ships/hurricane"
 	},
 	{
 		"name": "Banu Defender",
 		"url": "/pledge/ships/defender/Banu-Defender",
-		"thumbnail": "https://media.robertsspaceindustries.com/nnb2oofnrlni9/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/nnb2oofnrlni9/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/defender"
 	},
 	{
 		"name": "Eclipse",
 		"url": "/pledge/ships/eclipse/Eclipse",
-		"thumbnail": "/media/uqceivqlombzor/heap_infobox/Aegis-Eclipse-L4-Piece-2-Hangar-Presentation-007.jpg"
+		"thumbnail": "/media/uqceivqlombzor/heap_infobox/Aegis-Eclipse-L4-Piece-2-Hangar-Presentation-007.jpg",
+		"fleetyard": "https://fleetyards.net/ships/eclipse"
 	},
 	{
 		"name": "Nox",
 		"url": "/pledge/ships/nox/Nox",
-		"thumbnail": "https://media.robertsspaceindustries.com/8v2mfqoya3hnc/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/8v2mfqoya3hnc/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/nox"
 	},
 	{
 		"name": "Nox Kue",
 		"url": "/pledge/ships/nox/Nox-Kue",
-		"thumbnail": "https://media.robertsspaceindustries.com/qtdco5ba9acbc/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/qtdco5ba9acbc/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/nox-kue"
 	},
 	{
 		"name": "Cyclone",
 		"url": "/pledge/ships/cyclone/Cyclone",
-		"thumbnail": "/media/ao2p3pw2e7k94r/heap_infobox/Tumbril-Buggy-Piece-01-Showroom-V009.jpg"
+		"thumbnail": "/media/ao2p3pw2e7k94r/heap_infobox/Tumbril-Buggy-Piece-01-Showroom-V009.jpg",
+		"fleetyard": "https://fleetyards.net/ships/cyclone"
 	},
 	{
 		"name": "Cyclone-TR",
 		"url": "/pledge/ships/cyclone/Cyclone-TR",
-		"thumbnail": "/media/cmq3rwpo5ghpvr/heap_infobox/Tumbril-Buggy-Piece-04-Desert-V012.jpg"
+		"thumbnail": "/media/cmq3rwpo5ghpvr/heap_infobox/Tumbril-Buggy-Piece-04-Desert-V012.jpg",
+		"fleetyard": "https://fleetyards.net/ships/cyclone-tr"
 	},
 	{
 		"name": "Cyclone-RC",
 		"url": "/pledge/ships/cyclone/Cyclone-RC",
-		"thumbnail": "/media/w3vw5498xb25mr/heap_infobox/Tumbril-Buggy-Piece-05-Rocky-Beach-Sport-Fin.jpg"
+		"thumbnail": "/media/w3vw5498xb25mr/heap_infobox/Tumbril-Buggy-Piece-05-Rocky-Beach-Sport-Fin.jpg",
+		"fleetyard": "https://fleetyards.net/ships/cyclone-rc"
 	},
 	{
 		"name": "Cyclone-RN",
 		"url": "/pledge/ships/cyclone/Cyclone-RN",
-		"thumbnail": "/media/vj0pi3ibl7k4zr/heap_infobox/Tumbril-Buggy-Piece-07-Black-Beach-V012a.jpg"
+		"thumbnail": "/media/vj0pi3ibl7k4zr/heap_infobox/Tumbril-Buggy-Piece-07-Black-Beach-V012a.jpg",
+		"fleetyard": "https://fleetyards.net/ships/cyclone-rn"
 	},
 	{
 		"name": "Cyclone-AA",
 		"url": "/pledge/ships/cyclone/Cyclone-AA",
-		"thumbnail": "/media/n6535dpiwv2pgr/heap_infobox/Tumbril-Buggy-Piece-06-Lagoon-V011.jpg"
+		"thumbnail": "/media/n6535dpiwv2pgr/heap_infobox/Tumbril-Buggy-Piece-06-Lagoon-V011.jpg",
+		"fleetyard": "https://fleetyards.net/ships/cyclone-aa"
 	},
 	{
 		"name": "Ursa Rover",
 		"url": "/pledge/ships/ursa/Ursa-Rover",
-		"thumbnail": "https://media.robertsspaceindustries.com/1pyqpmzccb5jq/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/1pyqpmzccb5jq/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ursa-rover"
 	},
 	{
 		"name": "Ursa Rover Fortuna",
 		"url": "/pledge/ships/ursa/Ursa-Rover-Fortuna",
-		"thumbnail": "https://media.robertsspaceindustries.com/g62q7c3956cu1/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/g62q7c3956cu1/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ursa-rover-fortuna"
 	},
 	{
 		"name": "600i Touring",
 		"url": "/pledge/ships/600i/600i-Touring",
-		"thumbnail": "/media/z642zdp6d3mkzr/heap_infobox/600i-Touring.jpg"
+		"thumbnail": "/media/z642zdp6d3mkzr/heap_infobox/600i-Touring.jpg",
+		"fleetyard": "https://fleetyards.net/ships/600i-touring"
 	},
 	{
 		"name": "600i Explorer",
 		"url": "/pledge/ships/600i/600i-Explorer",
-		"thumbnail": "https://media.robertsspaceindustries.com/n285kdnihheez/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/n285kdnihheez/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/600i-explorer"
 	},
 	{
 		"name": "X1 Base",
 		"url": "/pledge/ships/x1/X1-Base",
-		"thumbnail": "/media/ktxtqr3rikt88r/heap_infobox/X1_base_white.png"
+		"thumbnail": "/media/ktxtqr3rikt88r/heap_infobox/X1_base_white.png",
+		"fleetyard": "https://fleetyards.net/ships/x1-base"
 	},
 	{
 		"name": "X1 Velocity",
 		"url": "/pledge/ships/x1/X1-Velocity",
-		"thumbnail": "https://media.robertsspaceindustries.com/1ddi6cnazo8bh/heap_infobox.png"
+		"thumbnail": "https://media.robertsspaceindustries.com/1ddi6cnazo8bh/heap_infobox.png",
+		"fleetyard": "https://fleetyards.net/ships/x1-velocity"
 	},
 	{
 		"name": "X1 Force",
 		"url": "/pledge/ships/x1/X1-Force",
-		"thumbnail": "https://media.robertsspaceindustries.com/b096uxlb9jvje/heap_infobox.png"
+		"thumbnail": "https://media.robertsspaceindustries.com/b096uxlb9jvje/heap_infobox.png",
+		"fleetyard": "https://fleetyards.net/ships/x1-force"
 	},
 	{
 		"name": "Pioneer",
 		"url": "/pledge/ships/pioneer/Pioneer",
-		"thumbnail": "/media/d1fv8alr2v0cgr/heap_infobox/Drydoc-4-Final.jpg"
+		"thumbnail": "/media/d1fv8alr2v0cgr/heap_infobox/Drydoc-4-Final.jpg",
+		"fleetyard": "https://fleetyards.net/ships/pioneer"
 	},
 	{
 		"name": "Hawk",
 		"url": "/pledge/ships/hawk/Hawk",
-		"thumbnail": "/media/r48azchzf281xr/heap_infobox/Ah-Promo-Shot-01b.jpg"
+		"thumbnail": "/media/r48azchzf281xr/heap_infobox/Ah-Promo-Shot-01b.jpg",
+		"fleetyard": "https://fleetyards.net/ships/hawk"
 	},
 	{
 		"name": "Hammerhead",
 		"url": "/pledge/ships/hammerhead/Hammerhead",
-		"thumbnail": "https://media.robertsspaceindustries.com/93zcfnzsy6xnu/heap_infobox.png"
+		"thumbnail": "https://media.robertsspaceindustries.com/93zcfnzsy6xnu/heap_infobox.png",
+		"fleetyard": "https://fleetyards.net/ships/hammerhead"
 	},
 	{
 		"name": "Hammerhead Best In Show Edition",
@@ -629,67 +743,80 @@ HangarXPLOR._ships = [
 	{
 		"name": "Nova",
 		"url": "/pledge/ships/nova-tank/Nova",
-		"thumbnail": "/media/ul5zp2zllebm2r/heap_infobox/TMBL_HeavyTank_ShotG_PJ03-Squashed.jpg"
+		"thumbnail": "/media/ul5zp2zllebm2r/heap_infobox/TMBL_HeavyTank_ShotG_PJ03-Squashed.jpg",
+		"fleetyard": "https://fleetyards.net/ships/nova"
 	},
 	{
 		"name": "Vulcan",
 		"url": "/pledge/ships/vulcan/Vulcan",
-		"thumbnail": "https://media.robertsspaceindustries.com/6q50bb3oy5q8b/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/6q50bb3oy5q8b/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/vulcan"
 	},
 	{
 		"name": "100i",
 		"url": "/pledge/ships/origin-100/100i",
-		"thumbnail": "https://media.robertsspaceindustries.com/ntdv7khpw1hpz/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/ntdv7khpw1hpz/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/100i"
 	},
 	{
 		"name": "125a",
 		"url": "/pledge/ships/origin-100/125a",
-		"thumbnail": "https://media.robertsspaceindustries.com/5nerri3qlhrxc/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/5nerri3qlhrxc/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/125a"
 	},
 	{
 		"name": "135c",
 		"url": "/pledge/ships/origin-100/135c",
-		"thumbnail": "https://media.robertsspaceindustries.com/nm7aeugyam4v4/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/nm7aeugyam4v4/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/135c"
 	},
 	{
 		"name": "C2 Hercules",
 		"url": "/pledge/ships/crusader-starlifter/C2-Hercules",
-		"thumbnail": "/media/7bdt759toqnvhr/heap_infobox/CRUS_Starlifter_Promo_Basic_Landed_MO01-Squashed.jpg"
+		"thumbnail": "/media/7bdt759toqnvhr/heap_infobox/CRUS_Starlifter_Promo_Basic_Landed_MO01-Squashed.jpg",
+		"fleetyard": "https://fleetyards.net/ships/c2-hercules"
 	},
 	{
 		"name": "M2 Hercules",
 		"url": "/pledge/ships/crusader-starlifter/M2-Hercules",
-		"thumbnail": "/media/p077b9nm14i11r/heap_infobox/CRUS_Starlifter_Promo_Military_Flares_MO01-Squashed.jpg"
+		"thumbnail": "/media/p077b9nm14i11r/heap_infobox/CRUS_Starlifter_Promo_Military_Flares_MO01-Squashed.jpg",
+		"fleetyard": "https://fleetyards.net/ships/m2-hercules"
 	},
 	{
 		"name": "A2 Hercules",
 		"url": "/pledge/ships/crusader-starlifter/A2-Hercules",
-		"thumbnail": "/media/kct1e9vkx4ld6r/heap_infobox/CRUS_Starlifter_Promo_Gunship_Bombing_MO02-Squashed.jpg"
+		"thumbnail": "/media/kct1e9vkx4ld6r/heap_infobox/CRUS_Starlifter_Promo_Gunship_Bombing_MO02-Squashed.jpg",
+		"fleetyard": "https://fleetyards.net/ships/a2-hercules"
 	},
 	{
 		"name": "Vulture",
 		"url": "/pledge/ships/drake-vulture/Vulture",
-		"thumbnail": "https://media.robertsspaceindustries.com/whe7eao2yqmjm/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/whe7eao2yqmjm/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/vulture"
 	},
 	{
 		"name": "Apollo Triage",
 		"url": "/pledge/ships/rsi-apollo/Apollo-Triage",
-		"thumbnail": "/media/63a4wxazxdzlir/heap_infobox/RSI_Apollo_SalesIcons_Red_PJ01-Squashed.jpg"
+		"thumbnail": "/media/63a4wxazxdzlir/heap_infobox/RSI_Apollo_SalesIcons_Red_PJ01-Squashed.jpg",
+		"fleetyard": "https://fleetyards.net/ships/apollo-triage"
 	},
 	{
 		"name": "Apollo Medivac",
 		"url": "/pledge/ships/rsi-apollo/Apollo-Medivac",
-		"thumbnail": "https://media.robertsspaceindustries.com/an87zna125f7d/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/an87zna125f7d/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/apollo-medivac"
 	},
 	{
 		"name": "Mercury Star Runner",
 		"url": "/pledge/ships/crusader-mercury-star-runner/Mercury-Star-Runner",
-		"thumbnail": "/media/1fv0hyr8qml6vr/heap_infobox/Crusader-Starrunner-Birds-Eye-Min-1.jpeg"
+		"thumbnail": "/media/1fv0hyr8qml6vr/heap_infobox/Crusader-Starrunner-Birds-Eye-Min-1.jpeg",
+		"fleetyard": "https://fleetyards.net/ships/mercury-star-runner"
 	},
 	{
 		"name": "Valkyrie",
 		"url": "/pledge/ships/anvil-valkyrie/Valkyrie",
-		"thumbnail": "https://media.robertsspaceindustries.com/9ypuudni1cbl6/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/9ypuudni1cbl6/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/valkyrie"
 	},
 	{
 		"name": "Valkyrie Liberator Edition",
@@ -699,17 +826,20 @@ HangarXPLOR._ships = [
 	{
 		"name": "Kraken",
 		"url": "/pledge/ships/drake-kraken/Kraken",
-		"thumbnail": "https://media.robertsspaceindustries.com/39mq5sef3eek2/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/39mq5sef3eek2/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/kraken"
 	},
 	{
 		"name": "Kraken Privateer",
 		"url": "/pledge/ships/drake-kraken/Kraken-Privateer",
-		"thumbnail": "https://media.robertsspaceindustries.com/nnu9953me3vod/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/nnu9953me3vod/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/kraken-privateer"
 	},
 	{
 		"name": "Arrow",
 		"url": "/pledge/ships/anvil-arrow/Arrow",
-		"thumbnail": "https://media.robertsspaceindustries.com/th8oqphlhb0bk/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/th8oqphlhb0bk/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/arrow"
 	},
 	{
 		"name": "San'tok.yāi",
@@ -719,32 +849,38 @@ HangarXPLOR._ships = [
 	{
 		"name": "SRV",
 		"url": "/pledge/ships/argo-srv/SRV",
-		"thumbnail": "https://media.robertsspaceindustries.com/aojn1qvitpt1s/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/aojn1qvitpt1s/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/srv"
 	},
 	{
 		"name": "Corsair",
 		"url": "/pledge/ships/drake-corsair/Corsair",
-		"thumbnail": "https://media.robertsspaceindustries.com/2xatcl9uglt91/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/2xatcl9uglt91/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/corsair"
 	},
 	{
 		"name": "Ranger RC",
 		"url": "/pledge/ships/tumbril-ranger/Ranger-RC",
-		"thumbnail": "https://media.robertsspaceindustries.com/dwmsr86x3doif/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/dwmsr86x3doif/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ranger-rc"
 	},
 	{
 		"name": "Ranger TR",
 		"url": "/pledge/ships/tumbril-ranger/Ranger-TR",
-		"thumbnail": "https://media.robertsspaceindustries.com/5bcok11mha9hp/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/5bcok11mha9hp/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ranger-tr"
 	},
 	{
 		"name": "Ranger CV",
 		"url": "/pledge/ships/tumbril-ranger/Ranger-CV",
-		"thumbnail": "/media/a9ukhl4werezmr/heap_infobox/Cargo-Min.jpg"
+		"thumbnail": "/media/a9ukhl4werezmr/heap_infobox/Cargo-Min.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ranger-cv"
 	},
 	{
 		"name": "Anvil Ballista ",
 		"url": "/pledge/ships/anvil-ballista/Anvil-Ballista",
-		"thumbnail": "https://media.robertsspaceindustries.com/y3adiaqxq3v9e/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/y3adiaqxq3v9e/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ballista"
 	},
 	{
 		"name": "Anvil Ballista Snowblind",
@@ -759,7 +895,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Nautilus ",
 		"url": "/pledge/ships/aegis-nautilus/Nautilus",
-		"thumbnail": "https://media.robertsspaceindustries.com/c6t6mr400hgx6/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/c6t6mr400hgx6/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/nautilus"
 	},
 	{
 		"name": "Nautilus Solstice Edition",
@@ -769,32 +906,38 @@ HangarXPLOR._ships = [
 	{
 		"name": "Mantis",
 		"url": "/pledge/ships/rsi-mantis/Mantis",
-		"thumbnail": "https://media.robertsspaceindustries.com/srd2tmizujvbo/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/srd2tmizujvbo/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mantis"
 	},
 	{
 		"name": "C8 Pisces",
 		"url": "/pledge/ships/anvil-pisces/C8-Pisces",
-		"thumbnail": "https://media.robertsspaceindustries.com/9y6uxd82fw0ne/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/9y6uxd82fw0ne/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/c8-pisces"
 	},
 	{
 		"name": "C8X Pisces Expedition ",
 		"url": "/pledge/ships/anvil-pisces/C8X-Pisces-Expedition",
-		"thumbnail": "https://media.robertsspaceindustries.com/kj7oh12zn2f1l/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/kj7oh12zn2f1l/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/c8x-pisces-expedition"
 	},
 	{
 		"name": "Crusader Ares Inferno ",
 		"url": "/pledge/ships/crusader-ares/Crusader-Ares-Inferno",
-		"thumbnail": "https://media.robertsspaceindustries.com/hg5k6498yhyzp/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/hg5k6498yhyzp/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ares-inferno"
 	},
 	{
 		"name": "Crusader Ares Ion",
 		"url": "/pledge/ships/crusader-ares/Crusader-Ares-Ion",
-		"thumbnail": "https://media.robertsspaceindustries.com/820xdzlyfr9lg/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/820xdzlyfr9lg/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ares-ion"
 	},
 	{
 		"name": "Argo Mole",
 		"url": "/pledge/ships/argo-mole/Argo-Mole",
-		"thumbnail": "/media/oyl9g7aqg17smr/heap_infobox/ARGO_Mole_Space_122019.jpg"
+		"thumbnail": "/media/oyl9g7aqg17smr/heap_infobox/ARGO_Mole_Space_122019.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mole"
 	},
 	{
 		"name": "Argo Mole Carbon Edition",
@@ -809,41 +952,49 @@ HangarXPLOR._ships = [
 	{
 		"name": "Origin G12",
 		"url": "/pledge/ships/origin-g12/Origin-G12",
-		"thumbnail": "https://media.robertsspaceindustries.com/brmi1ci9rthmu/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/brmi1ci9rthmu/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/g12"
 	},
 	{
 		"name": "Origin G12r",
 		"url": "/pledge/ships/origin-g12/Origin-G12r",
-		"thumbnail": "https://media.robertsspaceindustries.com/ou0nkzhocb2bd/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/ou0nkzhocb2bd/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/g12r"
 	},
 	{
 		"name": "Origin G12a",
 		"url": "/pledge/ships/origin-g12/Origin-G12a",
-		"thumbnail": "https://media.robertsspaceindustries.com/2btmuamt8zv4g/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/2btmuamt8zv4g/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/g12a"
 	},
 	{
 		"name": "Esperia Talon",
 		"url": "/pledge/ships/talon/Esperia-Talon",
-		"thumbnail": "https://media.robertsspaceindustries.com/e92yq6jha5uzs/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/e92yq6jha5uzs/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/talon"
 	},
 	{
 		"name": "Esperia Talon Shrike",
 		"url": "/pledge/ships/talon/Esperia-Talon-Shrike",
-		"thumbnail": "https://media.robertsspaceindustries.com/3gsfs0i1etq71/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/3gsfs0i1etq71/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/talon-shrike"
 	},
 	{
 		"name": "ROC",
 		"url": "/pledge/ships/roc/ROC",
-		"thumbnail": "https://media.robertsspaceindustries.com/wo06flt432pjs/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/wo06flt432pjs/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/roc"
 	},
 	{
 		"name": "CNOU Nomad",
 		"url": "/pledge/ships/nomad/CNOU-Nomad",
-		"thumbnail": "https://media.robertsspaceindustries.com/fcqc4k2uwgpbr/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/fcqc4k2uwgpbr/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/nomad"
 	},
 	{
 		"name": "RSI Perseus",
 		"url": "/pledge/ships/perseus/RSI-Perseus",
-		"thumbnail": "https://media.robertsspaceindustries.com/wzzgz1hzpl4bs/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/wzzgz1hzpl4bs/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/perseus"
 	}
 ]

--- a/src/web_resources/HangarXPLOR.Ships.js
+++ b/src/web_resources/HangarXPLOR.Ships.js
@@ -4,368 +4,307 @@ HangarXPLOR._ships = [
 	{
 		"name": "Aurora ES",
 		"url": "/pledge/ships/rsi-aurora/Aurora-ES",
-		"thumbnail": "https://media.robertsspaceindustries.com/pnxa8gu3m0wut/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/aurora-es"
+		"thumbnail": "https://media.robertsspaceindustries.com/pnxa8gu3m0wut/heap_infobox.jpg"
 	},
 	{
 		"name": "Aurora LX",
 		"url": "/pledge/ships/rsi-aurora/Aurora-LX",
-		"thumbnail": "https://media.robertsspaceindustries.com/n08kif9wp2t94/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/aurora-lx"
+		"thumbnail": "https://media.robertsspaceindustries.com/n08kif9wp2t94/heap_infobox.jpg"
 	},
 	{
 		"name": "Aurora MR",
 		"url": "/pledge/ships/rsi-aurora/Aurora-MR",
-		"thumbnail": "https://media.robertsspaceindustries.com/7zbk19qeqy9fp/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/aurora-mr"
+		"thumbnail": "https://media.robertsspaceindustries.com/7zbk19qeqy9fp/heap_infobox.jpg"
 	},
 	{
 		"name": "Aurora CL",
 		"url": "/pledge/ships/rsi-aurora/Aurora-CL",
-		"thumbnail": "https://media.robertsspaceindustries.com/eqexi7735yer1/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/aurora-cl"
+		"thumbnail": "https://media.robertsspaceindustries.com/eqexi7735yer1/heap_infobox.jpg"
 	},
 	{
 		"name": "Aurora LN",
 		"url": "/pledge/ships/rsi-aurora/Aurora-LN",
-		"thumbnail": "https://media.robertsspaceindustries.com/0ufx8v9k7kult/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/aurora-ln"
+		"thumbnail": "https://media.robertsspaceindustries.com/0ufx8v9k7kult/heap_infobox.jpg"
 	},
 	{
 		"name": "300i",
 		"url": "/pledge/ships/origin-300/300i",
-		"thumbnail": "https://media.robertsspaceindustries.com/q5d6d32fzus8s/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/300i"
+		"thumbnail": "https://media.robertsspaceindustries.com/q5d6d32fzus8s/heap_infobox.jpg"
 	},
 	{
 		"name": "315p",
 		"url": "/pledge/ships/origin-300/315p",
-		"thumbnail": "https://media.robertsspaceindustries.com/zd6vxsvdq0gxp/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/315p"
+		"thumbnail": "https://media.robertsspaceindustries.com/zd6vxsvdq0gxp/heap_infobox.jpg"
 	},
 	{
 		"name": "325a",
 		"url": "/pledge/ships/origin-300/325a",
-		"thumbnail": "https://media.robertsspaceindustries.com/eesg17ack8awh/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/325a"
+		"thumbnail": "https://media.robertsspaceindustries.com/eesg17ack8awh/heap_infobox.jpg"
 	},
 	{
 		"name": "350r",
 		"url": "/pledge/ships/origin-300/350r",
-		"thumbnail": "https://media.robertsspaceindustries.com/7mk0roegof8jp/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/350r"
+		"thumbnail": "https://media.robertsspaceindustries.com/7mk0roegof8jp/heap_infobox.jpg"
 	},
 	{
 		"name": "F7C Hornet",
 		"url": "/pledge/ships/anvil-hornet/F7C-Hornet",
-		"thumbnail": "https://media.robertsspaceindustries.com/tcpakf2m1h1hx/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/f7c-hornet"
+		"thumbnail": "https://media.robertsspaceindustries.com/tcpakf2m1h1hx/heap_infobox.jpg"
 	},
 	{
 		"name": "F7C Hornet Wildfire",
 		"url": "/pledge/ships/anvil-hornet/F7C-Hornet-Wildfire",
-		"thumbnail": "/media/0ioeh7g90gnqsr/heap_infobox/Wildfire_render1.jpg",
-		"fleetyard": "https://fleetyards.net/ships/f7c-hornet-wildfire"
+		"thumbnail": "/media/0ioeh7g90gnqsr/heap_infobox/Wildfire_render1.jpg"
 	},
 	{
 		"name": "F7C-S Hornet Ghost",
 		"url": "/pledge/ships/anvil-hornet/F7C-S-Hornet-Ghost",
-		"thumbnail": "https://media.robertsspaceindustries.com/nbwncbo1436rs/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/f7c-s-hornet-ghost"
+		"thumbnail": "https://media.robertsspaceindustries.com/nbwncbo1436rs/heap_infobox.jpg"
 	},
 	{
 		"name": "F7C-R Hornet Tracker",
 		"url": "/pledge/ships/anvil-hornet/F7C-R-Hornet-Tracker",
-		"thumbnail": "https://media.robertsspaceindustries.com/biy2mmvcz6eb2/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/f7c-r-hornet-tracker"
+		"thumbnail": "https://media.robertsspaceindustries.com/biy2mmvcz6eb2/heap_infobox.jpg"
 	},
 	{
 		"name": "F7C-M Super Hornet",
 		"url": "/pledge/ships/anvil-hornet/F7C-M-Super-Hornet",
-		"thumbnail": "https://media.robertsspaceindustries.com/pjudaw3yj3odo/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/f7c-m-super-hornet"
+		"thumbnail": "https://media.robertsspaceindustries.com/pjudaw3yj3odo/heap_infobox.jpg"
 	},
 	{
 		"name": "F7A Hornet",
 		"url": "/pledge/ships/anvil-hornet/F7A-Hornet",
-		"thumbnail": "/media/j2ie1gy9x9zsbr/heap_infobox/F7a.jpg",
-		"fleetyard": "https://fleetyards.net/ships/f7a-hornet"
+		"thumbnail": "/media/j2ie1gy9x9zsbr/heap_infobox/F7a.jpg"
 	},
 	{
 		"name": "F7C-M Super Hornet Heartseeker",
 		"url": "/pledge/ships/anvil-hornet/F7C-M-Super-Hornet-Heartseeker",
-		"thumbnail": "https://media.robertsspaceindustries.com/6ewzke6o3llh6/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/f7c-m-super-hornet-heartseeker"
+		"thumbnail": "https://media.robertsspaceindustries.com/6ewzke6o3llh6/heap_infobox.jpg"
 	},
 	{
 		"name": "Constellation Aquila",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Aquila",
-		"thumbnail": "https://media.robertsspaceindustries.com/c2k21tjgn3z6a/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/constellation-aquila"
+		"thumbnail": "https://media.robertsspaceindustries.com/c2k21tjgn3z6a/heap_infobox.jpg"
 	},
 	{
 		"name": "Constellation Andromeda",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Andromeda",
-		"thumbnail": "https://media.robertsspaceindustries.com/b5wlk3qo9v3iq/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/constellation-andromeda"
+		"thumbnail": "https://media.robertsspaceindustries.com/b5wlk3qo9v3iq/heap_infobox.jpg"
 	},
 	{
 		"name": "Constellation Taurus",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Taurus",
-		"thumbnail": "/media/3vj4o4l5uggk7r/heap_infobox/Taurus-Storefront.jpg",
-		"fleetyard": "https://fleetyards.net/ships/constellation-taurus"
+		"thumbnail": "/media/3vj4o4l5uggk7r/heap_infobox/Taurus-Storefront.jpg"
 	},
 	{
 		"name": "Constellation Phoenix",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Phoenix",
-		"thumbnail": "https://media.robertsspaceindustries.com/jkyny550a90um/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/constellation-phoenix"
+		"thumbnail": "https://media.robertsspaceindustries.com/jkyny550a90um/heap_infobox.jpg"
 	},
 	{
 		"name": "Constellation Phoenix Emerald",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Phoenix-Emerald",
-		"thumbnail": "/media/kkakjxny421xfr/heap_infobox/Connie_Emerald.jpg",
-		"fleetyard": "https://fleetyards.net/ships/constellation-phoenix"
+		"thumbnail": "/media/kkakjxny421xfr/heap_infobox/Connie_Emerald.jpg"
 	},
 	{
 		"name": "Freelancer",
 		"url": "/pledge/ships/misc-freelancer/Freelancer",
-		"thumbnail": "https://media.robertsspaceindustries.com/z3mllk6zi0x7r/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/freelancer"
+		"thumbnail": "https://media.robertsspaceindustries.com/z3mllk6zi0x7r/heap_infobox.jpg"
 	},
 	{
 		"name": "Freelancer DUR",
 		"url": "/pledge/ships/misc-freelancer/Freelancer-DUR",
-		"thumbnail": "https://media.robertsspaceindustries.com/d5tl8fqymjuf7/heap_infobox.png",
-		"fleetyard": "https://fleetyards.net/ships/freelancer-dur"
+		"thumbnail": "https://media.robertsspaceindustries.com/d5tl8fqymjuf7/heap_infobox.png"
 	},
 	{
 		"name": "Freelancer MAX",
 		"url": "/pledge/ships/misc-freelancer/Freelancer-MAX",
-		"thumbnail": "https://media.robertsspaceindustries.com/tllo2q10dvzmi/heap_infobox.png",
-		"fleetyard": "https://fleetyards.net/ships/freelancer-max"
+		"thumbnail": "https://media.robertsspaceindustries.com/tllo2q10dvzmi/heap_infobox.png"
 	},
 	{
 		"name": "Freelancer MIS",
 		"url": "/pledge/ships/misc-freelancer/Freelancer-MIS",
-		"thumbnail": "https://media.robertsspaceindustries.com/ybkygputhkx0g/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/freelancer-mis"
+		"thumbnail": "https://media.robertsspaceindustries.com/ybkygputhkx0g/heap_infobox.jpg"
 	},
 	{
 		"name": "Cutlass Black",
 		"url": "/pledge/ships/drake-cutlass/Cutlass-Black",
-		"thumbnail": "https://media.robertsspaceindustries.com/wj92rqzvhnecb/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/cutlass-black"
+		"thumbnail": "https://media.robertsspaceindustries.com/wj92rqzvhnecb/heap_infobox.jpg"
 	},
 	{
 		"name": "Cutlass Red",
 		"url": "/pledge/ships/drake-cutlass/Cutlass-Red",
-		"thumbnail": "https://media.robertsspaceindustries.com/c93bnty7qmhzb/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/cutlass-red"
+		"thumbnail": "https://media.robertsspaceindustries.com/c93bnty7qmhzb/heap_infobox.jpg"
 	},
 	{
 		"name": "Cutlass Blue",
 		"url": "/pledge/ships/drake-cutlass/Cutlass-Blue",
-		"thumbnail": "https://media.robertsspaceindustries.com/r7z7uznkhwojt/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/cutlass-blue"
+		"thumbnail": "https://media.robertsspaceindustries.com/r7z7uznkhwojt/heap_infobox.jpg"
 	},
 	{
 		"name": "Cutlass Black Best In Show Edition",
 		"url": "/pledge/ships/drake-cutlass/Cutlass-Black-Best-In-Show-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/vt0f0g30nua1v/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/cutlass-black"
+		"thumbnail": "https://media.robertsspaceindustries.com/vt0f0g30nua1v/heap_infobox.jpg"
 	},
 	{
 		"name": "Avenger Stalker",
 		"url": "/pledge/ships/aegis-avenger/Avenger-Stalker",
-		"thumbnail": "https://media.robertsspaceindustries.com/9tfhza1twrczn/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/avenger-stalker"
+		"thumbnail": "https://media.robertsspaceindustries.com/9tfhza1twrczn/heap_infobox.jpg"
 	},
 	{
 		"name": "Avenger Titan Renegade",
 		"url": "/pledge/ships/aegis-avenger/Avenger-Titan-Renegade",
-		"thumbnail": "https://media.robertsspaceindustries.com/oc8p2v3n7c0e0/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/avenger-titan-renegade"
+		"thumbnail": "https://media.robertsspaceindustries.com/oc8p2v3n7c0e0/heap_infobox.jpg"
 	},
 	{
 		"name": "Avenger Warlock",
 		"url": "/pledge/ships/aegis-avenger/Avenger-Warlock",
-		"thumbnail": "https://media.robertsspaceindustries.com/l8znbwwoh2o8u/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/avenger-warlock"
+		"thumbnail": "https://media.robertsspaceindustries.com/l8znbwwoh2o8u/heap_infobox.jpg"
 	},
 	{
 		"name": "Avenger Titan",
 		"url": "/pledge/ships/aegis-avenger/Avenger-Titan",
-		"thumbnail": "https://media.robertsspaceindustries.com/fmhdkmvhi8ify/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/avenger-titan"
+		"thumbnail": "https://media.robertsspaceindustries.com/fmhdkmvhi8ify/heap_infobox.jpg"
 	},
 	{
 		"name": "Gladiator",
 		"url": "/pledge/ships/anvil-gladiator/Gladiator",
-		"thumbnail": "/media/ye6hvyo93oc2ar/heap_infobox/Gladiator-WB_FrontLeft.jpg",
-		"fleetyard": "https://fleetyards.net/ships/gladiator"
+		"thumbnail": "/media/ye6hvyo93oc2ar/heap_infobox/Gladiator-WB_FrontLeft.jpg"
 	},
 	{
 		"name": "M50",
 		"url": "/pledge/ships/origin-m50/M50",
-		"thumbnail": "https://media.robertsspaceindustries.com/rdj7iilxxhvet/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/m50"
+		"thumbnail": "https://media.robertsspaceindustries.com/rdj7iilxxhvet/heap_infobox.jpg"
 	},
 	{
 		"name": "Starfarer",
 		"url": "/pledge/ships/misc-starfarer/Starfarer",
-		"thumbnail": "https://media.robertsspaceindustries.com/5ukbyxyx8t6ek/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/starfarer"
+		"thumbnail": "https://media.robertsspaceindustries.com/5ukbyxyx8t6ek/heap_infobox.jpg"
 	},
 	{
 		"name": "Starfarer Gemini",
 		"url": "/pledge/ships/misc-starfarer/Starfarer-Gemini",
-		"thumbnail": "https://media.robertsspaceindustries.com/c6423etmvm52z/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/starfarer-gemini"
+		"thumbnail": "https://media.robertsspaceindustries.com/c6423etmvm52z/heap_infobox.jpg"
 	},
 	{
 		"name": "Caterpillar",
 		"url": "/pledge/ships/drake-caterpillar/Caterpillar",
-		"thumbnail": "https://media.robertsspaceindustries.com/d2lkocbd58mvc/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/caterpillar"
+		"thumbnail": "https://media.robertsspaceindustries.com/d2lkocbd58mvc/heap_infobox.jpg"
 	},
 	{
 		"name": "Caterpillar Pirate Edition",
 		"url": "/pledge/ships/drake-caterpillar/Caterpillar-Pirate-Edition",
-		"thumbnail": "/media/56cjes33yzdj6r/heap_infobox/Pirate_05.jpg",
-		"fleetyard": "https://fleetyards.net/ships/caterpillar"
+		"thumbnail": "/media/56cjes33yzdj6r/heap_infobox/Pirate_05.jpg"
 	},
 	{
 		"name": "Caterpillar Best In Show Edition",
 		"url": "/pledge/ships/drake-caterpillar/Caterpillar-Best-In-Show-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/1r1vf9peutpr0/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/caterpillar"
+		"thumbnail": "https://media.robertsspaceindustries.com/1r1vf9peutpr0/heap_infobox.jpg"
 	},
 	{
 		"name": "Retaliator Bomber",
 		"url": "/pledge/ships/aegis-retaliator/Retaliator-Bomber",
-		"thumbnail": "/media/kz6mu0tt0u06er/heap_infobox/Retaliator-Ortho_v2.jpg",
-		"fleetyard": "https://fleetyards.net/ships/retaliator-bomber"
+		"thumbnail": "/media/kz6mu0tt0u06er/heap_infobox/Retaliator-Ortho_v2.jpg"
 	},
 	{
 		"name": "Retaliator Base",
 		"url": "/pledge/ships/aegis-retaliator/Retaliator-Base",
-		"thumbnail": "https://media.robertsspaceindustries.com/sa6wyt4so2dtk/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/retaliator-base"
+		"thumbnail": "https://media.robertsspaceindustries.com/sa6wyt4so2dtk/heap_infobox.jpg"
 	},
 	{
 		"name": "Scythe",
 		"url": "/pledge/ships/scythe/Scythe",
-		"thumbnail": "/media/wdtdkzl0x31ver/heap_infobox/Vanduul-Scythe_storefront_visual.jpg",
-		"fleetyard": "https://fleetyards.net/ships/scythe"
+		"thumbnail": "/media/wdtdkzl0x31ver/heap_infobox/Vanduul-Scythe_storefront_visual.jpg"
 	},
 	{
 		"name": "Idris-M",
 		"url": "/pledge/ships/aegis-idris/Idris-M",
-		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg",
-		"fleetyard": "https://fleetyards.net/ships/idris-m"
+		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg"
 	},
 	{
 		"name": "Idris-P",
 		"url": "/pledge/ships/aegis-idris/Idris-P",
-		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg",
-		"fleetyard": "https://fleetyards.net/ships/idris-p"
+		"thumbnail": "/media/rfjjekm57en5jr/heap_infobox/IDRISdownfrontquarter_copy.jpg"
 	},
 	{
 		"name": "P-52 Merlin",
 		"url": "/pledge/ships/p52-merlin/P-52-Merlin",
-		"thumbnail": "/media/a9231ysz5cnvor/heap_infobox/Top.jpg",
-		"fleetyard": "https://fleetyards.net/ships/p-52-merlin"
+		"thumbnail": "/media/a9231ysz5cnvor/heap_infobox/Top.jpg"
 	},
 	{
 		"name": "Mustang Alpha",
 		"url": "/pledge/ships/mustang/Mustang-Alpha",
-		"thumbnail": "/media/cpq6ly29wmi1br/heap_infobox/56745675467.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mustang-alpha"
+		"thumbnail": "/media/cpq6ly29wmi1br/heap_infobox/56745675467.jpg"
 	},
 	{
 		"name": "Mustang Beta",
 		"url": "/pledge/ships/mustang/Mustang-Beta",
-		"thumbnail": "/media/4ws8rrspe10exr/heap_infobox/5675676578.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mustang-beta"
+		"thumbnail": "/media/4ws8rrspe10exr/heap_infobox/5675676578.jpg"
 	},
 	{
 		"name": "Mustang Gamma",
 		"url": "/pledge/ships/mustang/Mustang-Gamma",
-		"thumbnail": "/media/yu4cuzh90oz54r/heap_infobox/Gamma-Front.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mustang-gamma"
+		"thumbnail": "/media/yu4cuzh90oz54r/heap_infobox/Gamma-Front.jpg"
 	},
 	{
 		"name": "Mustang Delta",
 		"url": "/pledge/ships/mustang/Mustang-Delta",
-		"thumbnail": "https://media.robertsspaceindustries.com/s7ntca9x35tjl/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mustang-delta"
+		"thumbnail": "https://media.robertsspaceindustries.com/s7ntca9x35tjl/heap_infobox.jpg"
 	},
 	{
 		"name": "Mustang Omega",
 		"url": "/pledge/ships/mustang/Mustang-Omega",
-		"thumbnail": "/media/gmru9y7ynd1bbr/heap_infobox/Omega-Front.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mustang-omega"
+		"thumbnail": "/media/gmru9y7ynd1bbr/heap_infobox/Omega-Front.jpg"
 	},
 	{
 		"name": "Mustang Alpha Vindicator",
 		"url": "/pledge/ships/mustang/Mustang-Alpha-Vindicator",
-		"thumbnail": "https://media.robertsspaceindustries.com/iohmvf24h4rsz/heap_infobox.png",
-		"fleetyard": "https://fleetyards.net/ships/mustang-alpha"
+		"thumbnail": "https://media.robertsspaceindustries.com/iohmvf24h4rsz/heap_infobox.png"
 	},
 	{
 		"name": "Redeemer",
 		"url": "/pledge/ships/redeemer/Redeemer",
-		"thumbnail": "/media/t0opqw0tauo45r/heap_infobox/Red1.jpg",
-		"fleetyard": "https://fleetyards.net/ships/redeemer"
+		"thumbnail": "/media/t0opqw0tauo45r/heap_infobox/Red1.jpg"
 	},
 	{
 		"name": "Gladius",
 		"url": "/pledge/ships/gladius/Gladius",
-		"thumbnail": "https://media.robertsspaceindustries.com/xxdvidtr1ze6b/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/gladius"
+		"thumbnail": "https://media.robertsspaceindustries.com/xxdvidtr1ze6b/heap_infobox.jpg"
 	},
 	{
 		"name": "Gladius Valiant",
 		"url": "/pledge/ships/gladius/Gladius-Valiant",
-		"thumbnail": "/media/mpszlemby5r43r/heap_infobox/Gladius_variant_sale_img.jpg",
-		"fleetyard": "https://fleetyards.net/ships/gladius-valiant"
+		"thumbnail": "/media/mpszlemby5r43r/heap_infobox/Gladius_variant_sale_img.jpg"
 	},
 	{
 		"name": "Pirate Gladius",
 		"url": "/pledge/ships/gladius/Pirate-Gladius",
-		"thumbnail": "https://media.robertsspaceindustries.com/9cwz2utclixvt/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/pirate-gladius"
+		"thumbnail": "https://media.robertsspaceindustries.com/9cwz2utclixvt/heap_infobox.jpg"
 	},
 	{
 		"name": "Khartu-Al",
 		"url": "/pledge/ships/khartu/Khartu-Al",
-		"thumbnail": "https://media.robertsspaceindustries.com/g8xkja21h9rep/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/khartu-al"
+		"thumbnail": "https://media.robertsspaceindustries.com/g8xkja21h9rep/heap_infobox.jpg"
 	},
 	{
 		"name": "Merchantman",
 		"url": "/pledge/ships/merchantman/Merchantman",
-		"thumbnail": "https://media.robertsspaceindustries.com/6z00b42zydbnm/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/merchantman"
+		"thumbnail": "https://media.robertsspaceindustries.com/6z00b42zydbnm/heap_infobox.jpg"
 	},
 	{
 		"name": "890 Jump",
 		"url": "/pledge/ships/890-jump/890-Jump",
-		"thumbnail": "https://media.robertsspaceindustries.com/t2bky2nbdg0ms/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/890-jump"
+		"thumbnail": "https://media.robertsspaceindustries.com/t2bky2nbdg0ms/heap_infobox.jpg"
 	},
 	{
 		"name": "Carrack",
 		"url": "/pledge/ships/carrack/Carrack",
-		"thumbnail": "/media/uacgp8oc20yekr/heap_infobox/Carrack.jpg",
-		"fleetyard": "https://fleetyards.net/ships/carrack"
+		"thumbnail": "/media/uacgp8oc20yekr/heap_infobox/Carrack.jpg"
 	},
 	{
 		"name": "Carrack w/C8X",
 		"url": "/pledge/ships/carrack/Carrack-W-C8X",
-		"thumbnail": "https://media.robertsspaceindustries.com/twlkwwqy2mmk2/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/carrack"
+		"thumbnail": "https://media.robertsspaceindustries.com/twlkwwqy2mmk2/heap_infobox.jpg"
 	},
 	{
 		"name": "Carrack Expedition w/C8X",
@@ -375,482 +314,402 @@ HangarXPLOR._ships = [
 	{
 		"name": "Carrack Expedition",
 		"url": "/pledge/ships/carrack/Carrack-Expedition",
-		"thumbnail": "https://media.robertsspaceindustries.com/gpfapokelyewn/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/carrack"
+		"thumbnail": "https://media.robertsspaceindustries.com/gpfapokelyewn/heap_infobox.jpg"
 	},
 	{
 		"name": "Herald",
 		"url": "/pledge/ships/herald/Herald",
-		"thumbnail": "https://media.robertsspaceindustries.com/xcbs8bs50xo23/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/herald"
+		"thumbnail": "https://media.robertsspaceindustries.com/xcbs8bs50xo23/heap_infobox.jpg"
 	},
 	{
 		"name": "Hull C",
 		"url": "/pledge/ships/hull/Hull-C",
-		"thumbnail": "/media/w54u21vkhci5vr/heap_infobox/Hull_C_Final.jpg",
-		"fleetyard": "https://fleetyards.net/ships/hull-c"
+		"thumbnail": "/media/w54u21vkhci5vr/heap_infobox/Hull_C_Final.jpg"
 	},
 	{
 		"name": "Hull A",
 		"url": "/pledge/ships/hull/Hull-A",
-		"thumbnail": "/media/tpw5r365mowmar/heap_infobox/Hull_A_Final.jpg",
-		"fleetyard": "https://fleetyards.net/ships/hull-a"
+		"thumbnail": "/media/tpw5r365mowmar/heap_infobox/Hull_A_Final.jpg"
 	},
 	{
 		"name": "Hull B",
 		"url": "/pledge/ships/hull/Hull-B",
-		"thumbnail": "/media/xg8d8kyo0bjsmr/heap_infobox/HullB_landedcompv3b.jpg",
-		"fleetyard": "https://fleetyards.net/ships/hull-b"
+		"thumbnail": "/media/xg8d8kyo0bjsmr/heap_infobox/HullB_landedcompv3b.jpg"
 	},
 	{
 		"name": "Hull D",
 		"url": "/pledge/ships/hull/Hull-D",
-		"thumbnail": "https://media.robertsspaceindustries.com/1j6650dnbblli/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/hull-d"
+		"thumbnail": "https://media.robertsspaceindustries.com/1j6650dnbblli/heap_infobox.jpg"
 	},
 	{
 		"name": "Hull E",
 		"url": "/pledge/ships/hull/Hull-E",
-		"thumbnail": "/media/xyt1qu08sjmy3r/heap_infobox/Hull_E_3_compflat.jpg",
-		"fleetyard": "https://fleetyards.net/ships/hull-e"
+		"thumbnail": "/media/xyt1qu08sjmy3r/heap_infobox/Hull_E_3_compflat.jpg"
 	},
 	{
 		"name": "Orion",
 		"url": "/pledge/ships/orion/Orion",
-		"thumbnail": "/media/hfpnkupg7gr6er/heap_infobox/RSI_Orion_Situ1b_150219_GH.jpg",
-		"fleetyard": "https://fleetyards.net/ships/orion"
+		"thumbnail": "/media/hfpnkupg7gr6er/heap_infobox/RSI_Orion_Situ1b_150219_GH.jpg"
 	},
 	{
 		"name": "Reclaimer",
 		"url": "/pledge/ships/reclaimer/Reclaimer",
-		"thumbnail": "https://media.robertsspaceindustries.com/iweivr5xyt5j1/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/reclaimer"
+		"thumbnail": "https://media.robertsspaceindustries.com/iweivr5xyt5j1/heap_infobox.jpg"
 	},
 	{
 		"name": "Reclaimer Best In Show Edition",
 		"url": "/pledge/ships/reclaimer/Reclaimer-Best-In-Show-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/81432ksmdzn30/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/reclaimer"
+		"thumbnail": "https://media.robertsspaceindustries.com/81432ksmdzn30/heap_infobox.jpg"
 	},
 	{
 		"name": "Javelin",
 		"url": "/pledge/ships/aegis-javelin/Javelin",
-		"thumbnail": "https://media.robertsspaceindustries.com/oc89p5ksizcla/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/javelin"
+		"thumbnail": "https://media.robertsspaceindustries.com/oc89p5ksizcla/heap_infobox.jpg"
 	},
 	{
 		"name": "Vanguard Warden",
 		"url": "/pledge/ships/vanguard/Vanguard-Warden",
-		"thumbnail": "https://media.robertsspaceindustries.com/sgzm3dw5q0o3y/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/vanguard-warden"
+		"thumbnail": "https://media.robertsspaceindustries.com/sgzm3dw5q0o3y/heap_infobox.jpg"
 	},
 	{
 		"name": "Vanguard Harbinger",
 		"url": "/pledge/ships/vanguard/Vanguard-Harbinger",
-		"thumbnail": "https://media.robertsspaceindustries.com/enygi6572pnkl/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/vanguard-harbinger"
+		"thumbnail": "https://media.robertsspaceindustries.com/enygi6572pnkl/heap_infobox.jpg"
 	},
 	{
 		"name": "Vanguard Sentinel",
 		"url": "/pledge/ships/vanguard/Vanguard-Sentinel",
-		"thumbnail": "https://media.robertsspaceindustries.com/4e4e30eyvq6d6/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/vanguard-sentinel"
+		"thumbnail": "https://media.robertsspaceindustries.com/4e4e30eyvq6d6/heap_infobox.jpg"
 	},
 	{
 		"name": "Vanguard Hoplite",
 		"url": "/pledge/ships/vanguard/Vanguard-Hoplite",
-		"thumbnail": "/media/zwyyyap3aa7wwr/heap_infobox/Aegis_Vanguard_Hoplite_01.jpg",
-		"fleetyard": "https://fleetyards.net/ships/vanguard-hoplite"
+		"thumbnail": "/media/zwyyyap3aa7wwr/heap_infobox/Aegis_Vanguard_Hoplite_01.jpg"
 	},
 	{
 		"name": "Reliant Kore",
 		"url": "/pledge/ships/reliant/Reliant-Kore",
-		"thumbnail": "https://media.robertsspaceindustries.com/hyi1vmyi6ppj6/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/reliant-kore"
+		"thumbnail": "https://media.robertsspaceindustries.com/hyi1vmyi6ppj6/heap_infobox.jpg"
 	},
 	{
 		"name": "Reliant Mako",
 		"url": "/pledge/ships/reliant/Reliant-Mako",
-		"thumbnail": "https://media.robertsspaceindustries.com/awmk2vgihtpf9/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/reliant-mako"
+		"thumbnail": "https://media.robertsspaceindustries.com/awmk2vgihtpf9/heap_infobox.jpg"
 	},
 	{
 		"name": "Reliant Sen",
 		"url": "/pledge/ships/reliant/Reliant-Sen",
-		"thumbnail": "https://media.robertsspaceindustries.com/8ewkdvinyoy4c/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/reliant-sen"
+		"thumbnail": "https://media.robertsspaceindustries.com/8ewkdvinyoy4c/heap_infobox.jpg"
 	},
 	{
 		"name": "Reliant Tana",
 		"url": "/pledge/ships/reliant/Reliant-Tana",
-		"thumbnail": "https://media.robertsspaceindustries.com/qe3ifzhvxdcww/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/reliant-tana"
+		"thumbnail": "https://media.robertsspaceindustries.com/qe3ifzhvxdcww/heap_infobox.jpg"
 	},
 	{
 		"name": "Genesis Starliner",
 		"url": "/pledge/ships/starliner/Genesis-Starliner",
-		"thumbnail": "/media/iqk7vt4xay0zfr/heap_infobox/Starliner_action1_runwaycompFlat.jpg",
-		"fleetyard": "https://fleetyards.net/ships/genesis-starliner"
+		"thumbnail": "/media/iqk7vt4xay0zfr/heap_infobox/Starliner_action1_runwaycompFlat.jpg"
 	},
 	{
 		"name": "Glaive",
 		"url": "/pledge/ships/esperia-glaive/Glaive",
-		"thumbnail": "https://media.robertsspaceindustries.com/gk4dk2ip4w1ia/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/glaive"
+		"thumbnail": "https://media.robertsspaceindustries.com/gk4dk2ip4w1ia/heap_infobox.jpg"
 	},
 	{
 		"name": "Endeavor",
 		"url": "/pledge/ships/misc-endeavor/Endeavor",
-		"thumbnail": "/media/vh2jbjaom7ys4r/heap_infobox/CO_Beauty_BioDomes.jpg",
-		"fleetyard": "https://fleetyards.net/ships/endeavor"
+		"thumbnail": "/media/vh2jbjaom7ys4r/heap_infobox/CO_Beauty_BioDomes.jpg"
 	},
 	{
 		"name": "Sabre",
 		"url": "/pledge/ships/sabre/Sabre",
-		"thumbnail": "https://media.robertsspaceindustries.com/p32tq6jjp301r/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/sabre"
+		"thumbnail": "https://media.robertsspaceindustries.com/p32tq6jjp301r/heap_infobox.jpg"
 	},
 	{
 		"name": "Sabre Comet",
 		"url": "/pledge/ships/sabre/Sabre-Comet",
-		"thumbnail": "/media/8pmglyd0scvhar/heap_infobox/Sabre_variant_sale_img.jpg",
-		"fleetyard": "https://fleetyards.net/ships/sabre-comet"
+		"thumbnail": "/media/8pmglyd0scvhar/heap_infobox/Sabre_variant_sale_img.jpg"
 	},
 	{
 		"name": "Sabre Raven",
 		"url": "/pledge/ships/sabre/Sabre-Raven",
-		"thumbnail": "/media/3q1dirw16ezv5r/heap_infobox/3_4_front_raven_blue_Enlarge_Crop.jpg",
-		"fleetyard": "https://fleetyards.net/ships/sabre-raven"
+		"thumbnail": "/media/3q1dirw16ezv5r/heap_infobox/3_4_front_raven_blue_Enlarge_Crop.jpg"
 	},
 	{
 		"name": "Crucible",
 		"url": "/pledge/ships/crucible/Crucible",
-		"thumbnail": "https://media.robertsspaceindustries.com/q81gvelwf2usv/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/crucible"
+		"thumbnail": "https://media.robertsspaceindustries.com/q81gvelwf2usv/heap_infobox.jpg"
 	},
 	{
 		"name": "P72 Archimedes",
 		"url": "/pledge/ships/p72-archimedes/P72-Archimedes",
-		"thumbnail": "/media/xqgbgw3x6o54ir/heap_infobox/Archimedes_Front_01.jpg",
-		"fleetyard": "https://fleetyards.net/ships/p-72-archimedes"
+		"thumbnail": "/media/xqgbgw3x6o54ir/heap_infobox/Archimedes_Front_01.jpg"
 	},
 	{
 		"name": "P72 Archimedes Emerald",
 		"url": "/pledge/ships/p72-archimedes/P72-Archimedes-Emerald",
-		"thumbnail": "/media/o94ip9isoyjmhr/heap_infobox/Archimedes-Sku-Image-V3.jpg",
-		"fleetyard": "https://fleetyards.net/ships/p-72-archimedes"
+		"thumbnail": "/media/o94ip9isoyjmhr/heap_infobox/Archimedes-Sku-Image-V3.jpg"
 	},
 	{
 		"name": "Blade",
 		"url": "/pledge/ships/vanduul-blade/Blade",
-		"thumbnail": "https://media.robertsspaceindustries.com/hyp6k1cu5qh8a/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/blade"
+		"thumbnail": "https://media.robertsspaceindustries.com/hyp6k1cu5qh8a/heap_infobox.jpg"
 	},
 	{
 		"name": "Prospector",
 		"url": "/pledge/ships/misc-prospector/Prospector",
-		"thumbnail": "https://media.robertsspaceindustries.com/bsrfd5pqb769v/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/prospector"
+		"thumbnail": "https://media.robertsspaceindustries.com/bsrfd5pqb769v/heap_infobox.jpg"
 	},
 	{
 		"name": "Buccaneer",
 		"url": "/pledge/ships/drake-buccaneer/Buccaneer",
-		"thumbnail": "/media/eiua12z9nxlkar/heap_infobox/Buc_final120_compFlat.jpg",
-		"fleetyard": "https://fleetyards.net/ships/buccaneer"
+		"thumbnail": "/media/eiua12z9nxlkar/heap_infobox/Buc_final120_compFlat.jpg"
 	},
 	{
 		"name": "Dragonfly Yellowjacket",
 		"url": "/pledge/ships/drake-dragonfly/Dragonfly-Yellowjacket",
-		"thumbnail": "/media/am12jusvbx8mqr/heap_infobox/Dragonfly-Left.jpg",
-		"fleetyard": "https://fleetyards.net/ships/dragonfly-yellowjacket"
+		"thumbnail": "/media/am12jusvbx8mqr/heap_infobox/Dragonfly-Left.jpg"
 	},
 	{
 		"name": "Dragonfly Black",
 		"url": "/pledge/ships/drake-dragonfly/Dragonfly-Black",
-		"thumbnail": "/media/5v25a4lwtbdlar/heap_infobox/Dragonfly-Black-Left.jpg",
-		"fleetyard": "https://fleetyards.net/ships/dragonfly-black"
+		"thumbnail": "/media/5v25a4lwtbdlar/heap_infobox/Dragonfly-Black-Left.jpg"
 	},
 	{
 		"name": "MPUV Personnel",
 		"url": "/pledge/ships/argo/MPUV-Personnel",
-		"thumbnail": "/media/fgi7cen4bdvzkr/heap_infobox/Landing_v01.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mpuv-personnel"
+		"thumbnail": "/media/fgi7cen4bdvzkr/heap_infobox/Landing_v01.jpg"
 	},
 	{
 		"name": "MPUV Cargo",
 		"url": "/pledge/ships/argo/MPUV-Cargo",
-		"thumbnail": "/media/mywvchg9tot3xr/heap_infobox/BatCave_4k_v02.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mpuv-cargo"
+		"thumbnail": "/media/mywvchg9tot3xr/heap_infobox/BatCave_4k_v02.jpg"
 	},
 	{
 		"name": "Terrapin",
 		"url": "/pledge/ships/terrapin/Terrapin",
-		"thumbnail": "/media/ijkzkcb5t1w8zr/heap_infobox/Anvil_Terrapin_Piece_03_Surveilance_v3.jpg",
-		"fleetyard": "https://fleetyards.net/ships/terrapin"
+		"thumbnail": "/media/ijkzkcb5t1w8zr/heap_infobox/Anvil_Terrapin_Piece_03_Surveilance_v3.jpg"
 	},
 	{
 		"name": "Polaris",
 		"url": "/pledge/ships/polaris/Polaris",
-		"thumbnail": "https://media.robertsspaceindustries.com/6dw8h0adz1y3s/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/polaris"
+		"thumbnail": "https://media.robertsspaceindustries.com/6dw8h0adz1y3s/heap_infobox.jpg"
 	},
 	{
 		"name": "Prowler",
 		"url": "/pledge/ships/prowler/Prowler",
-		"thumbnail": "/media/3j9cau4jygwier/heap_infobox/Esperia_Prowler_SHOT_01b.jpg",
-		"fleetyard": "https://fleetyards.net/ships/prowler"
+		"thumbnail": "/media/3j9cau4jygwier/heap_infobox/Esperia_Prowler_SHOT_01b.jpg"
 	},
 	{
 		"name": "85X",
 		"url": "/pledge/ships/85x/85X",
-		"thumbnail": "/media/4vht65hve2o1cr/heap_infobox/85_X_city_shot.jpg",
-		"fleetyard": "https://fleetyards.net/ships/85x"
+		"thumbnail": "/media/4vht65hve2o1cr/heap_infobox/85_X_city_shot.jpg"
 	},
 	{
 		"name": "Razor",
 		"url": "/pledge/ships/razor/Razor",
-		"thumbnail": "https://media.robertsspaceindustries.com/wltzple6y1hy4/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/razor"
+		"thumbnail": "https://media.robertsspaceindustries.com/wltzple6y1hy4/heap_infobox.jpg"
 	},
 	{
 		"name": "Razor EX",
 		"url": "/pledge/ships/razor/Razor-EX",
-		"thumbnail": "https://media.robertsspaceindustries.com/qn84a6os8q3db/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/razor-ex"
+		"thumbnail": "https://media.robertsspaceindustries.com/qn84a6os8q3db/heap_infobox.jpg"
 	},
 	{
 		"name": "Razor LX",
 		"url": "/pledge/ships/razor/Razor-LX",
-		"thumbnail": "https://media.robertsspaceindustries.com/xjp3pxmsvoxzb/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/razor-lx"
+		"thumbnail": "https://media.robertsspaceindustries.com/xjp3pxmsvoxzb/heap_infobox.jpg"
 	},
 	{
 		"name": "Hurricane",
 		"url": "/pledge/ships/hurricane/Hurricane",
-		"thumbnail": "/media/iupif96slteo0r/heap_infobox/Action_02-Squashed.jpg",
-		"fleetyard": "https://fleetyards.net/ships/hurricane"
+		"thumbnail": "/media/iupif96slteo0r/heap_infobox/Action_02-Squashed.jpg"
 	},
 	{
 		"name": "Banu Defender",
 		"url": "/pledge/ships/defender/Banu-Defender",
-		"thumbnail": "https://media.robertsspaceindustries.com/nnb2oofnrlni9/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/defender"
+		"thumbnail": "https://media.robertsspaceindustries.com/nnb2oofnrlni9/heap_infobox.jpg"
 	},
 	{
 		"name": "Eclipse",
 		"url": "/pledge/ships/eclipse/Eclipse",
-		"thumbnail": "/media/uqceivqlombzor/heap_infobox/Aegis-Eclipse-L4-Piece-2-Hangar-Presentation-007.jpg",
-		"fleetyard": "https://fleetyards.net/ships/eclipse"
+		"thumbnail": "/media/uqceivqlombzor/heap_infobox/Aegis-Eclipse-L4-Piece-2-Hangar-Presentation-007.jpg"
 	},
 	{
 		"name": "Nox",
 		"url": "/pledge/ships/nox/Nox",
-		"thumbnail": "https://media.robertsspaceindustries.com/8v2mfqoya3hnc/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/nox"
+		"thumbnail": "https://media.robertsspaceindustries.com/8v2mfqoya3hnc/heap_infobox.jpg"
 	},
 	{
 		"name": "Nox Kue",
 		"url": "/pledge/ships/nox/Nox-Kue",
-		"thumbnail": "https://media.robertsspaceindustries.com/qtdco5ba9acbc/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/nox-kue"
+		"thumbnail": "https://media.robertsspaceindustries.com/qtdco5ba9acbc/heap_infobox.jpg"
 	},
 	{
 		"name": "Cyclone",
 		"url": "/pledge/ships/cyclone/Cyclone",
-		"thumbnail": "/media/ao2p3pw2e7k94r/heap_infobox/Tumbril-Buggy-Piece-01-Showroom-V009.jpg",
-		"fleetyard": "https://fleetyards.net/ships/cyclone"
+		"thumbnail": "/media/ao2p3pw2e7k94r/heap_infobox/Tumbril-Buggy-Piece-01-Showroom-V009.jpg"
 	},
 	{
 		"name": "Cyclone-TR",
 		"url": "/pledge/ships/cyclone/Cyclone-TR",
-		"thumbnail": "/media/cmq3rwpo5ghpvr/heap_infobox/Tumbril-Buggy-Piece-04-Desert-V012.jpg",
-		"fleetyard": "https://fleetyards.net/ships/cyclone-tr"
+		"thumbnail": "/media/cmq3rwpo5ghpvr/heap_infobox/Tumbril-Buggy-Piece-04-Desert-V012.jpg"
 	},
 	{
 		"name": "Cyclone-RC",
 		"url": "/pledge/ships/cyclone/Cyclone-RC",
-		"thumbnail": "/media/w3vw5498xb25mr/heap_infobox/Tumbril-Buggy-Piece-05-Rocky-Beach-Sport-Fin.jpg",
-		"fleetyard": "https://fleetyards.net/ships/cyclone-rc"
+		"thumbnail": "/media/w3vw5498xb25mr/heap_infobox/Tumbril-Buggy-Piece-05-Rocky-Beach-Sport-Fin.jpg"
 	},
 	{
 		"name": "Cyclone-RN",
 		"url": "/pledge/ships/cyclone/Cyclone-RN",
-		"thumbnail": "/media/vj0pi3ibl7k4zr/heap_infobox/Tumbril-Buggy-Piece-07-Black-Beach-V012a.jpg",
-		"fleetyard": "https://fleetyards.net/ships/cyclone-rn"
+		"thumbnail": "/media/vj0pi3ibl7k4zr/heap_infobox/Tumbril-Buggy-Piece-07-Black-Beach-V012a.jpg"
 	},
 	{
 		"name": "Cyclone-AA",
 		"url": "/pledge/ships/cyclone/Cyclone-AA",
-		"thumbnail": "/media/n6535dpiwv2pgr/heap_infobox/Tumbril-Buggy-Piece-06-Lagoon-V011.jpg",
-		"fleetyard": "https://fleetyards.net/ships/cyclone-aa"
+		"thumbnail": "/media/n6535dpiwv2pgr/heap_infobox/Tumbril-Buggy-Piece-06-Lagoon-V011.jpg"
 	},
 	{
 		"name": "Ursa Rover",
 		"url": "/pledge/ships/ursa/Ursa-Rover",
-		"thumbnail": "https://media.robertsspaceindustries.com/1pyqpmzccb5jq/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ursa-rover"
+		"thumbnail": "https://media.robertsspaceindustries.com/1pyqpmzccb5jq/heap_infobox.jpg"
 	},
 	{
 		"name": "Ursa Rover Fortuna",
 		"url": "/pledge/ships/ursa/Ursa-Rover-Fortuna",
-		"thumbnail": "https://media.robertsspaceindustries.com/g62q7c3956cu1/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ursa-rover-fortuna"
+		"thumbnail": "https://media.robertsspaceindustries.com/g62q7c3956cu1/heap_infobox.jpg"
 	},
 	{
 		"name": "600i Touring",
 		"url": "/pledge/ships/600i/600i-Touring",
-		"thumbnail": "/media/z642zdp6d3mkzr/heap_infobox/600i-Touring.jpg",
-		"fleetyard": "https://fleetyards.net/ships/600i-touring"
+		"thumbnail": "/media/z642zdp6d3mkzr/heap_infobox/600i-Touring.jpg"
 	},
 	{
 		"name": "600i Explorer",
 		"url": "/pledge/ships/600i/600i-Explorer",
-		"thumbnail": "https://media.robertsspaceindustries.com/n285kdnihheez/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/600i-explorer"
+		"thumbnail": "https://media.robertsspaceindustries.com/n285kdnihheez/heap_infobox.jpg"
 	},
 	{
 		"name": "X1 Base",
 		"url": "/pledge/ships/x1/X1-Base",
-		"thumbnail": "/media/ktxtqr3rikt88r/heap_infobox/X1_base_white.png",
-		"fleetyard": "https://fleetyards.net/ships/x1-base"
+		"thumbnail": "/media/ktxtqr3rikt88r/heap_infobox/X1_base_white.png"
 	},
 	{
 		"name": "X1 Velocity",
 		"url": "/pledge/ships/x1/X1-Velocity",
-		"thumbnail": "https://media.robertsspaceindustries.com/1ddi6cnazo8bh/heap_infobox.png",
-		"fleetyard": "https://fleetyards.net/ships/x1-velocity"
+		"thumbnail": "https://media.robertsspaceindustries.com/1ddi6cnazo8bh/heap_infobox.png"
 	},
 	{
 		"name": "X1 Force",
 		"url": "/pledge/ships/x1/X1-Force",
-		"thumbnail": "https://media.robertsspaceindustries.com/b096uxlb9jvje/heap_infobox.png",
-		"fleetyard": "https://fleetyards.net/ships/x1-force"
+		"thumbnail": "https://media.robertsspaceindustries.com/b096uxlb9jvje/heap_infobox.png"
 	},
 	{
 		"name": "Pioneer",
 		"url": "/pledge/ships/pioneer/Pioneer",
-		"thumbnail": "/media/d1fv8alr2v0cgr/heap_infobox/Drydoc-4-Final.jpg",
-		"fleetyard": "https://fleetyards.net/ships/pioneer"
+		"thumbnail": "/media/d1fv8alr2v0cgr/heap_infobox/Drydoc-4-Final.jpg"
 	},
 	{
 		"name": "Hawk",
 		"url": "/pledge/ships/hawk/Hawk",
-		"thumbnail": "/media/r48azchzf281xr/heap_infobox/Ah-Promo-Shot-01b.jpg",
-		"fleetyard": "https://fleetyards.net/ships/hawk"
+		"thumbnail": "/media/r48azchzf281xr/heap_infobox/Ah-Promo-Shot-01b.jpg"
 	},
 	{
 		"name": "Hammerhead",
 		"url": "/pledge/ships/hammerhead/Hammerhead",
-		"thumbnail": "https://media.robertsspaceindustries.com/93zcfnzsy6xnu/heap_infobox.png",
-		"fleetyard": "https://fleetyards.net/ships/hammerhead"
+		"thumbnail": "https://media.robertsspaceindustries.com/93zcfnzsy6xnu/heap_infobox.png"
 	},
 	{
 		"name": "Hammerhead Best In Show Edition",
 		"url": "/pledge/ships/hammerhead/Hammerhead-Best-In-Show-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/tmuyqtlpfh64d/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/hammerhead"
+		"thumbnail": "https://media.robertsspaceindustries.com/tmuyqtlpfh64d/heap_infobox.jpg"
 	},
 	{
 		"name": "Nova",
 		"url": "/pledge/ships/nova-tank/Nova",
-		"thumbnail": "/media/ul5zp2zllebm2r/heap_infobox/TMBL_HeavyTank_ShotG_PJ03-Squashed.jpg",
-		"fleetyard": "https://fleetyards.net/ships/nova"
+		"thumbnail": "/media/ul5zp2zllebm2r/heap_infobox/TMBL_HeavyTank_ShotG_PJ03-Squashed.jpg"
 	},
 	{
 		"name": "Vulcan",
 		"url": "/pledge/ships/vulcan/Vulcan",
-		"thumbnail": "https://media.robertsspaceindustries.com/6q50bb3oy5q8b/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/vulcan"
+		"thumbnail": "https://media.robertsspaceindustries.com/6q50bb3oy5q8b/heap_infobox.jpg"
 	},
 	{
 		"name": "100i",
 		"url": "/pledge/ships/origin-100/100i",
-		"thumbnail": "https://media.robertsspaceindustries.com/ntdv7khpw1hpz/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/100i"
+		"thumbnail": "https://media.robertsspaceindustries.com/ntdv7khpw1hpz/heap_infobox.jpg"
 	},
 	{
 		"name": "125a",
 		"url": "/pledge/ships/origin-100/125a",
-		"thumbnail": "https://media.robertsspaceindustries.com/5nerri3qlhrxc/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/125a"
+		"thumbnail": "https://media.robertsspaceindustries.com/5nerri3qlhrxc/heap_infobox.jpg"
 	},
 	{
 		"name": "135c",
 		"url": "/pledge/ships/origin-100/135c",
-		"thumbnail": "https://media.robertsspaceindustries.com/nm7aeugyam4v4/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/135c"
+		"thumbnail": "https://media.robertsspaceindustries.com/nm7aeugyam4v4/heap_infobox.jpg"
 	},
 	{
 		"name": "C2 Hercules",
 		"url": "/pledge/ships/crusader-starlifter/C2-Hercules",
-		"thumbnail": "/media/7bdt759toqnvhr/heap_infobox/CRUS_Starlifter_Promo_Basic_Landed_MO01-Squashed.jpg",
-		"fleetyard": "https://fleetyards.net/ships/c2-hercules"
+		"thumbnail": "/media/7bdt759toqnvhr/heap_infobox/CRUS_Starlifter_Promo_Basic_Landed_MO01-Squashed.jpg"
 	},
 	{
 		"name": "M2 Hercules",
 		"url": "/pledge/ships/crusader-starlifter/M2-Hercules",
-		"thumbnail": "/media/p077b9nm14i11r/heap_infobox/CRUS_Starlifter_Promo_Military_Flares_MO01-Squashed.jpg",
-		"fleetyard": "https://fleetyards.net/ships/m2-hercules"
+		"thumbnail": "/media/p077b9nm14i11r/heap_infobox/CRUS_Starlifter_Promo_Military_Flares_MO01-Squashed.jpg"
 	},
 	{
 		"name": "A2 Hercules",
 		"url": "/pledge/ships/crusader-starlifter/A2-Hercules",
-		"thumbnail": "/media/kct1e9vkx4ld6r/heap_infobox/CRUS_Starlifter_Promo_Gunship_Bombing_MO02-Squashed.jpg",
-		"fleetyard": "https://fleetyards.net/ships/a2-hercules"
+		"thumbnail": "/media/kct1e9vkx4ld6r/heap_infobox/CRUS_Starlifter_Promo_Gunship_Bombing_MO02-Squashed.jpg"
 	},
 	{
 		"name": "Vulture",
 		"url": "/pledge/ships/drake-vulture/Vulture",
-		"thumbnail": "https://media.robertsspaceindustries.com/whe7eao2yqmjm/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/vulture"
+		"thumbnail": "https://media.robertsspaceindustries.com/whe7eao2yqmjm/heap_infobox.jpg"
 	},
 	{
 		"name": "Apollo Triage",
 		"url": "/pledge/ships/rsi-apollo/Apollo-Triage",
-		"thumbnail": "/media/63a4wxazxdzlir/heap_infobox/RSI_Apollo_SalesIcons_Red_PJ01-Squashed.jpg",
-		"fleetyard": "https://fleetyards.net/ships/apollo-triage"
+		"thumbnail": "/media/63a4wxazxdzlir/heap_infobox/RSI_Apollo_SalesIcons_Red_PJ01-Squashed.jpg"
 	},
 	{
 		"name": "Apollo Medivac",
 		"url": "/pledge/ships/rsi-apollo/Apollo-Medivac",
-		"thumbnail": "https://media.robertsspaceindustries.com/an87zna125f7d/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/apollo-medivac"
+		"thumbnail": "https://media.robertsspaceindustries.com/an87zna125f7d/heap_infobox.jpg"
 	},
 	{
 		"name": "Mercury Star Runner",
 		"url": "/pledge/ships/crusader-mercury-star-runner/Mercury-Star-Runner",
-		"thumbnail": "/media/1fv0hyr8qml6vr/heap_infobox/Crusader-Starrunner-Birds-Eye-Min-1.jpeg",
-		"fleetyard": "https://fleetyards.net/ships/mercury-star-runner"
+		"thumbnail": "/media/1fv0hyr8qml6vr/heap_infobox/Crusader-Starrunner-Birds-Eye-Min-1.jpeg"
 	},
 	{
 		"name": "Valkyrie",
 		"url": "/pledge/ships/anvil-valkyrie/Valkyrie",
-		"thumbnail": "https://media.robertsspaceindustries.com/9ypuudni1cbl6/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/valkyrie"
+		"thumbnail": "https://media.robertsspaceindustries.com/9ypuudni1cbl6/heap_infobox.jpg"
 	},
 	{
 		"name": "Valkyrie Liberator Edition",
 		"url": "/pledge/ships/anvil-valkyrie/Valkyrie-Liberator-Edition",
-		"thumbnail": "/media/l87lynolh4pxyr/heap_infobox/128934g7tt.jpg",
-		"fleetyard": "https://fleetyards.net/ships/valkyrie"
+		"thumbnail": "/media/l87lynolh4pxyr/heap_infobox/128934g7tt.jpg"
 	},
 	{
 		"name": "Kraken",
 		"url": "/pledge/ships/drake-kraken/Kraken",
-		"thumbnail": "https://media.robertsspaceindustries.com/39mq5sef3eek2/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/kraken"
+		"thumbnail": "https://media.robertsspaceindustries.com/39mq5sef3eek2/heap_infobox.jpg"
 	},
 	{
 		"name": "Kraken Privateer",
 		"url": "/pledge/ships/drake-kraken/Kraken-Privateer",
-		"thumbnail": "https://media.robertsspaceindustries.com/nnu9953me3vod/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/kraken-privateer"
+		"thumbnail": "https://media.robertsspaceindustries.com/nnu9953me3vod/heap_infobox.jpg"
 	},
 	{
 		"name": "Arrow",
 		"url": "/pledge/ships/anvil-arrow/Arrow",
-		"thumbnail": "https://media.robertsspaceindustries.com/th8oqphlhb0bk/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/arrow"
+		"thumbnail": "https://media.robertsspaceindustries.com/th8oqphlhb0bk/heap_infobox.jpg"
 	},
 	{
 		"name": "San'tok.yāi",
@@ -860,157 +719,131 @@ HangarXPLOR._ships = [
 	{
 		"name": "SRV",
 		"url": "/pledge/ships/argo-srv/SRV",
-		"thumbnail": "https://media.robertsspaceindustries.com/aojn1qvitpt1s/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/srv"
+		"thumbnail": "https://media.robertsspaceindustries.com/aojn1qvitpt1s/heap_infobox.jpg"
 	},
 	{
 		"name": "Corsair",
 		"url": "/pledge/ships/drake-corsair/Corsair",
-		"thumbnail": "https://media.robertsspaceindustries.com/2xatcl9uglt91/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/corsair"
+		"thumbnail": "https://media.robertsspaceindustries.com/2xatcl9uglt91/heap_infobox.jpg"
 	},
 	{
 		"name": "Ranger RC",
 		"url": "/pledge/ships/tumbril-ranger/Ranger-RC",
-		"thumbnail": "https://media.robertsspaceindustries.com/dwmsr86x3doif/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ranger-rc"
+		"thumbnail": "https://media.robertsspaceindustries.com/dwmsr86x3doif/heap_infobox.jpg"
 	},
 	{
 		"name": "Ranger TR",
 		"url": "/pledge/ships/tumbril-ranger/Ranger-TR",
-		"thumbnail": "https://media.robertsspaceindustries.com/5bcok11mha9hp/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ranger-tr"
+		"thumbnail": "https://media.robertsspaceindustries.com/5bcok11mha9hp/heap_infobox.jpg"
 	},
 	{
 		"name": "Ranger CV",
 		"url": "/pledge/ships/tumbril-ranger/Ranger-CV",
-		"thumbnail": "/media/a9ukhl4werezmr/heap_infobox/Cargo-Min.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ranger-cv"
+		"thumbnail": "/media/a9ukhl4werezmr/heap_infobox/Cargo-Min.jpg"
 	},
 	{
 		"name": "Anvil Ballista ",
 		"url": "/pledge/ships/anvil-ballista/Anvil-Ballista",
-		"thumbnail": "https://media.robertsspaceindustries.com/y3adiaqxq3v9e/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ballista"
+		"thumbnail": "https://media.robertsspaceindustries.com/y3adiaqxq3v9e/heap_infobox.jpg"
 	},
 	{
 		"name": "Anvil Ballista Snowblind",
 		"url": "/pledge/ships/anvil-ballista/Anvil-Ballista-Snowblind",
-		"thumbnail": "/media/a5nzp9tgvq2i5r/heap_infobox/Ballista_Snowblind-Min.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ballista"
+		"thumbnail": "/media/a5nzp9tgvq2i5r/heap_infobox/Ballista_Snowblind-Min.jpg"
 	},
 	{
 		"name": "Anvil Ballista Dunestalker",
 		"url": "/pledge/ships/anvil-ballista/Anvil-Ballista-Dunestalker",
-		"thumbnail": "/media/rjxw89rs3sk5wr/heap_infobox/Ballista_Dunestalker-Min.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ballista"
+		"thumbnail": "/media/rjxw89rs3sk5wr/heap_infobox/Ballista_Dunestalker-Min.jpg"
 	},
 	{
 		"name": "Nautilus ",
 		"url": "/pledge/ships/aegis-nautilus/Nautilus",
-		"thumbnail": "https://media.robertsspaceindustries.com/c6t6mr400hgx6/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/nautilus"
+		"thumbnail": "https://media.robertsspaceindustries.com/c6t6mr400hgx6/heap_infobox.jpg"
 	},
 	{
 		"name": "Nautilus Solstice Edition",
 		"url": "/pledge/ships/aegis-nautilus/Nautilus-Solstice-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/mp9p2pzrvdxw9/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/nautilus"
+		"thumbnail": "https://media.robertsspaceindustries.com/mp9p2pzrvdxw9/heap_infobox.jpg"
 	},
 	{
 		"name": "Mantis",
 		"url": "/pledge/ships/rsi-mantis/Mantis",
-		"thumbnail": "https://media.robertsspaceindustries.com/srd2tmizujvbo/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mantis"
+		"thumbnail": "https://media.robertsspaceindustries.com/srd2tmizujvbo/heap_infobox.jpg"
 	},
 	{
 		"name": "C8 Pisces",
 		"url": "/pledge/ships/anvil-pisces/C8-Pisces",
-		"thumbnail": "https://media.robertsspaceindustries.com/9y6uxd82fw0ne/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/c8-pisces"
+		"thumbnail": "https://media.robertsspaceindustries.com/9y6uxd82fw0ne/heap_infobox.jpg"
 	},
 	{
 		"name": "C8X Pisces Expedition ",
 		"url": "/pledge/ships/anvil-pisces/C8X-Pisces-Expedition",
-		"thumbnail": "https://media.robertsspaceindustries.com/kj7oh12zn2f1l/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/c8x-pisces-expedition"
+		"thumbnail": "https://media.robertsspaceindustries.com/kj7oh12zn2f1l/heap_infobox.jpg"
 	},
 	{
 		"name": "Crusader Ares Inferno ",
 		"url": "/pledge/ships/crusader-ares/Crusader-Ares-Inferno",
-		"thumbnail": "https://media.robertsspaceindustries.com/hg5k6498yhyzp/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ares-inferno"
+		"thumbnail": "https://media.robertsspaceindustries.com/hg5k6498yhyzp/heap_infobox.jpg"
 	},
 	{
 		"name": "Crusader Ares Ion",
 		"url": "/pledge/ships/crusader-ares/Crusader-Ares-Ion",
-		"thumbnail": "https://media.robertsspaceindustries.com/820xdzlyfr9lg/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/ares-ion"
+		"thumbnail": "https://media.robertsspaceindustries.com/820xdzlyfr9lg/heap_infobox.jpg"
 	},
 	{
 		"name": "Argo Mole",
 		"url": "/pledge/ships/argo-mole/Argo-Mole",
-		"thumbnail": "/media/oyl9g7aqg17smr/heap_infobox/ARGO_Mole_Space_122019.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mole"
+		"thumbnail": "/media/oyl9g7aqg17smr/heap_infobox/ARGO_Mole_Space_122019.jpg"
 	},
 	{
 		"name": "Argo Mole Carbon Edition",
 		"url": "/pledge/ships/argo-mole/Argo-Mole-Carbon-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/ugpy6i9pbgbax/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mole"
+		"thumbnail": "https://media.robertsspaceindustries.com/ugpy6i9pbgbax/heap_infobox.jpg"
 	},
 	{
 		"name": "Argo Mole Talus Edition",
 		"url": "/pledge/ships/argo-mole/Argo-Mole-Talus-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/ghac95q2ncobp/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/mole"
+		"thumbnail": "https://media.robertsspaceindustries.com/ghac95q2ncobp/heap_infobox.jpg"
 	},
 	{
 		"name": "Origin G12",
 		"url": "/pledge/ships/origin-g12/Origin-G12",
-		"thumbnail": "https://media.robertsspaceindustries.com/brmi1ci9rthmu/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/g12"
+		"thumbnail": "https://media.robertsspaceindustries.com/brmi1ci9rthmu/heap_infobox.jpg"
 	},
 	{
 		"name": "Origin G12r",
 		"url": "/pledge/ships/origin-g12/Origin-G12r",
-		"thumbnail": "https://media.robertsspaceindustries.com/ou0nkzhocb2bd/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/g12r"
+		"thumbnail": "https://media.robertsspaceindustries.com/ou0nkzhocb2bd/heap_infobox.jpg"
 	},
 	{
 		"name": "Origin G12a",
 		"url": "/pledge/ships/origin-g12/Origin-G12a",
-		"thumbnail": "https://media.robertsspaceindustries.com/2btmuamt8zv4g/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/g12a"
+		"thumbnail": "https://media.robertsspaceindustries.com/2btmuamt8zv4g/heap_infobox.jpg"
 	},
 	{
 		"name": "Esperia Talon",
 		"url": "/pledge/ships/talon/Esperia-Talon",
-		"thumbnail": "https://media.robertsspaceindustries.com/e92yq6jha5uzs/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/talon"
+		"thumbnail": "https://media.robertsspaceindustries.com/e92yq6jha5uzs/heap_infobox.jpg"
 	},
 	{
 		"name": "Esperia Talon Shrike",
 		"url": "/pledge/ships/talon/Esperia-Talon-Shrike",
-		"thumbnail": "https://media.robertsspaceindustries.com/3gsfs0i1etq71/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/talon-shrike"
+		"thumbnail": "https://media.robertsspaceindustries.com/3gsfs0i1etq71/heap_infobox.jpg"
 	},
 	{
 		"name": "ROC",
 		"url": "/pledge/ships/roc/ROC",
-		"thumbnail": "https://media.robertsspaceindustries.com/wo06flt432pjs/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/roc"
+		"thumbnail": "https://media.robertsspaceindustries.com/wo06flt432pjs/heap_infobox.jpg"
 	},
 	{
 		"name": "CNOU Nomad",
 		"url": "/pledge/ships/nomad/CNOU-Nomad",
-		"thumbnail": "https://media.robertsspaceindustries.com/fcqc4k2uwgpbr/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/nomad"
+		"thumbnail": "https://media.robertsspaceindustries.com/fcqc4k2uwgpbr/heap_infobox.jpg"
 	},
 	{
 		"name": "RSI Perseus",
 		"url": "/pledge/ships/perseus/RSI-Perseus",
-		"thumbnail": "https://media.robertsspaceindustries.com/wzzgz1hzpl4bs/heap_infobox.jpg",
-		"fleetyard": "https://fleetyards.net/ships/perseus"
+		"thumbnail": "https://media.robertsspaceindustries.com/wzzgz1hzpl4bs/heap_infobox.jpg"
 	}
 ]

--- a/src/web_resources/HangarXPLOR.Ships.js
+++ b/src/web_resources/HangarXPLOR.Ships.js
@@ -124,7 +124,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Constellation Phoenix Emerald",
 		"url": "/pledge/ships/rsi-constellation/Constellation-Phoenix-Emerald",
-		"thumbnail": "/media/kkakjxny421xfr/heap_infobox/Connie_Emerald.jpg"
+		"thumbnail": "/media/kkakjxny421xfr/heap_infobox/Connie_Emerald.jpg",
+		"fleetyard": "https://fleetyards.net/ships/constellation-phoenix"
 	},
 	{
 		"name": "Freelancer",
@@ -171,7 +172,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Cutlass Black Best In Show Edition",
 		"url": "/pledge/ships/drake-cutlass/Cutlass-Black-Best-In-Show-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/vt0f0g30nua1v/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/vt0f0g30nua1v/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/cutlass-black"
 	},
 	{
 		"name": "Avenger Stalker",
@@ -230,12 +232,14 @@ HangarXPLOR._ships = [
 	{
 		"name": "Caterpillar Pirate Edition",
 		"url": "/pledge/ships/drake-caterpillar/Caterpillar-Pirate-Edition",
-		"thumbnail": "/media/56cjes33yzdj6r/heap_infobox/Pirate_05.jpg"
+		"thumbnail": "/media/56cjes33yzdj6r/heap_infobox/Pirate_05.jpg",
+		"fleetyard": "https://fleetyards.net/ships/caterpillar"
 	},
 	{
 		"name": "Caterpillar Best In Show Edition",
 		"url": "/pledge/ships/drake-caterpillar/Caterpillar-Best-In-Show-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/1r1vf9peutpr0/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/1r1vf9peutpr0/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/caterpillar"
 	},
 	{
 		"name": "Retaliator Bomber",
@@ -306,7 +310,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Mustang Alpha Vindicator",
 		"url": "/pledge/ships/mustang/Mustang-Alpha-Vindicator",
-		"thumbnail": "https://media.robertsspaceindustries.com/iohmvf24h4rsz/heap_infobox.png"
+		"thumbnail": "https://media.robertsspaceindustries.com/iohmvf24h4rsz/heap_infobox.png",
+		"fleetyard": "https://fleetyards.net/ships/mustang-alpha"
 	},
 	{
 		"name": "Redeemer",
@@ -359,7 +364,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Carrack w/C8X",
 		"url": "/pledge/ships/carrack/Carrack-W-C8X",
-		"thumbnail": "https://media.robertsspaceindustries.com/twlkwwqy2mmk2/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/twlkwwqy2mmk2/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/carrack"
 	},
 	{
 		"name": "Carrack Expedition w/C8X",
@@ -369,7 +375,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Carrack Expedition",
 		"url": "/pledge/ships/carrack/Carrack-Expedition",
-		"thumbnail": "https://media.robertsspaceindustries.com/gpfapokelyewn/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/gpfapokelyewn/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/carrack"
 	},
 	{
 		"name": "Herald",
@@ -422,7 +429,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Reclaimer Best In Show Edition",
 		"url": "/pledge/ships/reclaimer/Reclaimer-Best-In-Show-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/81432ksmdzn30/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/81432ksmdzn30/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/reclaimer"
 	},
 	{
 		"name": "Javelin",
@@ -529,7 +537,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "P72 Archimedes Emerald",
 		"url": "/pledge/ships/p72-archimedes/P72-Archimedes-Emerald",
-		"thumbnail": "/media/o94ip9isoyjmhr/heap_infobox/Archimedes-Sku-Image-V3.jpg"
+		"thumbnail": "/media/o94ip9isoyjmhr/heap_infobox/Archimedes-Sku-Image-V3.jpg",
+		"fleetyard": "https://fleetyards.net/ships/p-72-archimedes"
 	},
 	{
 		"name": "Blade",
@@ -738,7 +747,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Hammerhead Best In Show Edition",
 		"url": "/pledge/ships/hammerhead/Hammerhead-Best-In-Show-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/tmuyqtlpfh64d/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/tmuyqtlpfh64d/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/hammerhead"
 	},
 	{
 		"name": "Nova",
@@ -821,7 +831,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Valkyrie Liberator Edition",
 		"url": "/pledge/ships/anvil-valkyrie/Valkyrie-Liberator-Edition",
-		"thumbnail": "/media/l87lynolh4pxyr/heap_infobox/128934g7tt.jpg"
+		"thumbnail": "/media/l87lynolh4pxyr/heap_infobox/128934g7tt.jpg",
+		"fleetyard": "https://fleetyards.net/ships/valkyrie"
 	},
 	{
 		"name": "Kraken",
@@ -885,12 +896,14 @@ HangarXPLOR._ships = [
 	{
 		"name": "Anvil Ballista Snowblind",
 		"url": "/pledge/ships/anvil-ballista/Anvil-Ballista-Snowblind",
-		"thumbnail": "/media/a5nzp9tgvq2i5r/heap_infobox/Ballista_Snowblind-Min.jpg"
+		"thumbnail": "/media/a5nzp9tgvq2i5r/heap_infobox/Ballista_Snowblind-Min.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ballista"
 	},
 	{
 		"name": "Anvil Ballista Dunestalker",
 		"url": "/pledge/ships/anvil-ballista/Anvil-Ballista-Dunestalker",
-		"thumbnail": "/media/rjxw89rs3sk5wr/heap_infobox/Ballista_Dunestalker-Min.jpg"
+		"thumbnail": "/media/rjxw89rs3sk5wr/heap_infobox/Ballista_Dunestalker-Min.jpg",
+		"fleetyard": "https://fleetyards.net/ships/ballista"
 	},
 	{
 		"name": "Nautilus ",
@@ -901,7 +914,8 @@ HangarXPLOR._ships = [
 	{
 		"name": "Nautilus Solstice Edition",
 		"url": "/pledge/ships/aegis-nautilus/Nautilus-Solstice-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/mp9p2pzrvdxw9/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/mp9p2pzrvdxw9/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/nautilus"
 	},
 	{
 		"name": "Mantis",
@@ -942,12 +956,14 @@ HangarXPLOR._ships = [
 	{
 		"name": "Argo Mole Carbon Edition",
 		"url": "/pledge/ships/argo-mole/Argo-Mole-Carbon-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/ugpy6i9pbgbax/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/ugpy6i9pbgbax/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mole"
 	},
 	{
 		"name": "Argo Mole Talus Edition",
 		"url": "/pledge/ships/argo-mole/Argo-Mole-Talus-Edition",
-		"thumbnail": "https://media.robertsspaceindustries.com/ghac95q2ncobp/heap_infobox.jpg"
+		"thumbnail": "https://media.robertsspaceindustries.com/ghac95q2ncobp/heap_infobox.jpg",
+		"fleetyard": "https://fleetyards.net/ships/mole"
 	},
 	{
 		"name": "Origin G12",


### PR DESCRIPTION
Hey :),
as requested in issue #19 I have added button to link to their ship detail page. It looks like this at the moment:

![https://i.imgur.com/9E8lCcy.png](https://i.imgur.com/9E8lCcy.png)

This was just an idea, and it might be better to add the link to the title and image, or somewhere else. I also added a script that can automatically generate the `src/web_resources/HangarXPLOR.Ships.js` file. In the script you can define this array to determine what fields you want to extract:

```js
const fields = {
    'name': 'name',
    'url': 'url',
    'thumbnail': 'media.0.images.heap_infobox'
};
```

The script can be executed by simply calling `npm run generate-ships-file`