### PR TITLE
Add buyback page support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,6 @@ This project aims to improve the default Hangar and Buyback pages at https://rob
 * Edge - On Hold
 * Safari - Not Scheduled
 
-## Documentation
-
-Detailed documentation is available in the [docs/](docs/) folder:
-
-* **[User Guide](docs/USER_GUIDE.md)** - Installation, features, and usage instructions
-* **[Developer Guide](docs/DEVELOPER_GUIDE.md)** - Architecture, build system, and API reference
-* **[Parsing System](docs/PARSING_SYSTEM.md)** - How pledge data is extracted from RSI pages
-* **[UI Components](docs/UI_COMPONENTS.md)** - UI component factories and rendering pipeline
-* **[AI Agent Context](docs/AI_AGENT_CONTEXT.md)** - Comprehensive reference for AI-assisted development
-
 # Screenshots
 
 ![New and improved UI](https://i.imgur.com/RNndHdv.png "New and improved UI")

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # HangarXPLOR [![Build status](https://ci.appveyor.com/api/projects/status/7j87vur0plpw74vx/branch/release?svg=true)](https://ci.appveyor.com/project/dolkensp/hangarxplor/branch/release)
 
-This project aims to improved the default Hangar page at https://robertsspaceindustries.com/account/pledges.
+This project aims to improve the default Hangar and Buyback pages at https://robertsspaceindustries.com/account/pledges.
 
-Current features include:
+## Hangar Page Features
+
 * Pre-load ALL pages of your hangar at once
 * Correct the thumbnail image for upgraded ships
 * Correct the name of upgraded ships for easier searching
@@ -15,6 +16,16 @@ Current features include:
 * Export your ships in [Hangar Transfer Format](https://docs.starcitizen.fans/) for use with other apps
 * Export your ships in CSV format
 
+## Buyback Page Features
+
+* Pre-load ALL pages of your buyback queue at once
+* Filter by type: Ships, Game Packages, Upgrades, Paints, Add-Ons, Components, Weapons, Hangar Decorations, Subscriber Items
+* Sort by: Recent First, Name A-Z, Name Z-A, Type, Last Modified
+* Search across item names, types, and contained items
+* Pagination controls with customizable items per page
+* Summary panel showing total item counts by type
+* Export buyback items in JSON or CSV format
+
 ## Browser Support 
 
 * [Google Chrome Extension](https://chrome.google.com/webstore/detail/hangarxplor/bhkgemjdepodofcnmekdobmmbifemhkc/)
@@ -22,6 +33,16 @@ Current features include:
 * [Opera Add-On](https://addons.opera.com/en-gb/extensions/details/star-citizen-hangar-xplorer/)
 * Edge - On Hold
 * Safari - Not Scheduled
+
+## Documentation
+
+Detailed documentation is available in the [docs/](docs/) folder:
+
+* **[User Guide](docs/USER_GUIDE.md)** - Installation, features, and usage instructions
+* **[Developer Guide](docs/DEVELOPER_GUIDE.md)** - Architecture, build system, and API reference
+* **[Parsing System](docs/PARSING_SYSTEM.md)** - How pledge data is extracted from RSI pages
+* **[UI Components](docs/UI_COMPONENTS.md)** - UI component factories and rendering pipeline
+* **[AI Agent Context](docs/AI_AGENT_CONTEXT.md)** - Comprehensive reference for AI-assisted development
 
 # Screenshots
 

--- a/src/content_scripts/loader.js
+++ b/src/content_scripts/loader.js
@@ -43,6 +43,16 @@
     'web_resources/HangarXPLOR.Components.js',
     'web_resources/HangarXPLOR.Button.js',
     'web_resources/HangarXPLOR.BulkUI.js',
+    // Buyback page support
+    'web_resources/HangarXPLOR.BuybackBulkUI.js',
+    'web_resources/HangarXPLOR.DrawBuybackUI.js',
+    'web_resources/HangarXPLOR.RenderBuyback.js',
+    'web_resources/HangarXPLOR.FilterBuyback.js',
+    'web_resources/HangarXPLOR.SaveBuybackCache.js',
+    'web_resources/HangarXPLOR.LoadBuybackCache.js',
+    'web_resources/HangarXPLOR.ProcessBuybackPage.js',
+    'web_resources/HangarXPLOR.LoadBuybackPage.js',
+    'web_resources/HangarXPLOR.ParseBuybackPledge.js',
     'web_resources/shims.chrome.storage.js'
   ];
   

--- a/src/manifest.core.json
+++ b/src/manifest.core.json
@@ -27,7 +27,9 @@
       {
           "matches": [
               "https://robertsspaceindustries.com/*/account/pledges*",
-              "https://www.robertsspaceindustries.com/*/account/pledges*"
+              "https://www.robertsspaceindustries.com/*/account/pledges*",
+              "https://robertsspaceindustries.com/*/account/buy-back-pledges*",
+              "https://www.robertsspaceindustries.com/*/account/buy-back-pledges*"
           ],
           "js": [
               "content_scripts/loader.js"
@@ -81,6 +83,15 @@
               "web_resources/HangarXPLOR.Debug.js",
               "web_resources/HangarXPLOR.js",
               "web_resources/HangarXPLOR.css",
+              "web_resources/HangarXPLOR.ParseBuybackPledge.js",
+              "web_resources/HangarXPLOR.LoadBuybackPage.js",
+              "web_resources/HangarXPLOR.ProcessBuybackPage.js",
+              "web_resources/HangarXPLOR.LoadBuybackCache.js",
+              "web_resources/HangarXPLOR.SaveBuybackCache.js",
+              "web_resources/HangarXPLOR.FilterBuyback.js",
+              "web_resources/HangarXPLOR.RenderBuyback.js",
+              "web_resources/HangarXPLOR.DrawBuybackUI.js",
+              "web_resources/HangarXPLOR.BuybackBulkUI.js",
               "debug/*.html"
           ]
       }

--- a/src/web_resources/HangarXPLOR.BulkUI.js
+++ b/src/web_resources/HangarXPLOR.BulkUI.js
@@ -94,10 +94,24 @@ HangarXPLOR.BindBulkUI = function()
   
 }
 
-HangarXPLOR.UpdateStatus = function()
+HangarXPLOR.UpdateStatus = function(pageNo)
 {
+  // Handle buyback page
+  if (HangarXPLOR._pageType === 'buyback' && HangarXPLOR.$buybackBulkUI) {
+    HangarXPLOR.$buybackBulkUI.$loading.empty();
+    HangarXPLOR.$buybackBulkUI.$loading.append(
+      $('<span>', { class: 'amount', text: 'Loading' }),
+      $('<span>', { class: 'label', text: pageNo ? 'Page ' + pageNo : 'Please Wait' }),
+      $('<br>')
+    );
+    return;
+  }
+
+  // Handle hangar page
+  if (!HangarXPLOR.$bulkUI) return;
+
   HangarXPLOR.$bulkUI.$loading.empty();
-  
+
   HangarXPLOR.$bulkUI.$loading.append(
     $('<span>', { class: 'amount', text: 'Loading' }),
     $('<span>', { class: 'label', text: 'Please Wait' }),

--- a/src/web_resources/HangarXPLOR.BuybackBulkUI.js
+++ b/src/web_resources/HangarXPLOR.BuybackBulkUI.js
@@ -1,0 +1,110 @@
+
+var HangarXPLOR = HangarXPLOR || {};
+
+HangarXPLOR.$buybackBulkUI = null;
+
+/**
+ * Creates the buyback summary panel UI
+ * Shows counts by type and availability status
+ */
+HangarXPLOR.BuybackBulkUI = function() {
+  var $billing = $('#billing');
+
+  if ($billing.length === 0) {
+    // Fallback to body if #billing doesn't exist
+    $billing = $('body');
+  }
+
+  HangarXPLOR.$buybackBulkUI = $('<div>', { class: 'js-bulk-ui js-buyback-bulk-ui' });
+
+  HangarXPLOR.$buybackBulkUI.$inner = $('<div>', { class: 'inner content-block1 loading' });
+  HangarXPLOR.$buybackBulkUI.$value = $('<div>', { class: 'value' });
+  HangarXPLOR.$buybackBulkUI.$downloads = $('<div>', { class: 'actions' });
+  HangarXPLOR.$buybackBulkUI.$loading = $('<div>', { class: 'status value' });
+
+  $billing.append(HangarXPLOR.$buybackBulkUI);
+  HangarXPLOR.$buybackBulkUI.append(HangarXPLOR.$buybackBulkUI.$inner);
+  HangarXPLOR.$buybackBulkUI.$inner.append(
+    HangarXPLOR.$buybackBulkUI.$loading,
+    HangarXPLOR.$buybackBulkUI.$value,
+    HangarXPLOR.$buybackBulkUI.$downloads,
+    $('<div>', { class: 'top-line-thin' }),
+    $('<div>', { class: 'top-line' }),
+    $('<div>', { class: 'corner corner-top-right' }),
+    $('<div>', { class: 'corner corner-bottom-right' })
+  );
+
+  // Add download buttons
+  HangarXPLOR.$buybackBulkUI.$downloads.append(
+    HangarXPLOR.Button('Download CSV', 'download js-download-buyback-csv', HangarXPLOR._callbacks.DownloadBuybackCSV)
+  );
+  HangarXPLOR.$buybackBulkUI.$downloads.append(
+    HangarXPLOR.Button('Download JSON', 'download js-download-buyback-json', HangarXPLOR._callbacks.DownloadBuybackJSON)
+  );
+
+  // Position the UI
+  var positionUI = function() {
+    var scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+    var minOffset = 150;
+
+    if (scrollTop < minOffset) {
+      HangarXPLOR.$buybackBulkUI[0].style.top = (minOffset - scrollTop + 150) + 'px';
+    } else {
+      HangarXPLOR.$buybackBulkUI[0].style.top = '160px';
+    }
+  };
+
+  $(document).on('scroll', positionUI);
+  positionUI();
+};
+
+/**
+ * Refreshes the buyback summary panel with current counts
+ */
+HangarXPLOR.RefreshBuybackBulkUI = function() {
+  if (!HangarXPLOR.$buybackBulkUI) return;
+
+  HangarXPLOR.$buybackBulkUI.$inner.removeClass('loading');
+  HangarXPLOR.$buybackBulkUI.$value.empty();
+
+  var counts = HangarXPLOR._buybackCounts;
+
+  // Total count
+  HangarXPLOR.$buybackBulkUI.$value.append(
+    $('<div>', { class: 'buyback-summary-row' }).append(
+      $('<span>', { class: 'amount', text: counts.total }),
+      $('<span>', { class: 'label', text: 'Total Buyback Items' })
+    )
+  );
+
+  // Type breakdown - vertical list
+  var $typeBreakdown = $('<div>', { class: 'buyback-type-breakdown' });
+
+  // Define all types to display
+  var types = [
+    { count: counts.ships, label: 'Ships' },
+    { count: counts.packages, label: 'Packages' },
+    { count: counts.upgrades, label: 'Upgrades' },
+    { count: counts.paints, label: 'Paints' },
+    { count: counts.addons, label: 'Add-Ons' },
+    { count: counts.components, label: 'Components' },
+    { count: counts.weapons, label: 'Weapons' },
+    { count: counts.decorations, label: 'Decorations' },
+    { count: counts.subscriber, label: 'Subscriber' },
+    { count: counts.other, label: 'Other' }
+  ];
+
+  // Only show types with count > 0
+  types.forEach(function(type) {
+    if (type.count > 0) {
+      $typeBreakdown.append(
+        $('<div>', { class: 'buyback-count-row' }).append(
+          $('<span>', { class: 'count-num', text: type.count }),
+          $('<span>', { class: 'count-label', text: type.label })
+        )
+      );
+    }
+  });
+
+  HangarXPLOR.$buybackBulkUI.$value.append($typeBreakdown);
+};

--- a/src/web_resources/HangarXPLOR.Download.js
+++ b/src/web_resources/HangarXPLOR.Download.js
@@ -87,9 +87,9 @@ HangarXPLOR._exportByName = HangarXPLOR._exportByName || {};
   
   HangarXPLOR._callbacks.DownloadCSV = function(e) {
     e.preventDefault();
-    
+
     var $target = $(HangarXPLOR._selected.length > 0 ? HangarXPLOR._selected : HangarXPLOR._inventory);
-    
+
     // TODO: CSV support will need to be careful of user-entered data...
     var buffer = "Manufacturer, Ship, Lti, Warbond, ID, Pledge, Cost, Date\n";
     buffer = buffer + HangarXPLOR.GetShipList($target).map(function(ship) { return [ '"' + ship.manufacturer_name + '"', '"' + ship.ship_name + '"', ship.lti, ship.warbond, ship.pledge_id, '"' + ship.pledge_name + '"', '"' + ship.pledge_cost + '"', '"' + ship.pledge_date + '"' ].join(',')}).join('\n')
@@ -99,4 +99,88 @@ HangarXPLOR._exportByName = HangarXPLOR._exportByName || {};
     $download.attr('type', 'text/csv');
     $download[0].click();
   }
+
+  // =============================================
+  // Buyback Export Functions
+  // =============================================
+
+  /**
+   * Gets the buyback list for export
+   * @param {Array} target - Array of buyback items to export (optional, defaults to full inventory)
+   * @returns {Array} Array of buyback item objects
+   */
+  HangarXPLOR.GetBuybackList = function(target) {
+    var items = target || HangarXPLOR._buybackInventory;
+
+    return $.map(items, function(item) {
+      return {
+        type: item.buyback_type,
+        name: item.buyback_name,
+        pledge_id: item.pledge_id,
+        last_modified: item.last_modified,
+        contained: item.contained,
+        is_available: item.is_available
+      };
+    });
+  };
+
+  /**
+   * Downloads buyback inventory as JSON
+   */
+  HangarXPLOR._callbacks.DownloadBuybackJSON = function(e) {
+    e.preventDefault();
+
+    var exportData = {
+      fetched_at: new Date().toISOString(),
+      total_items: HangarXPLOR._buybackInventory.length,
+      counts: HangarXPLOR._buybackCounts,
+      items: HangarXPLOR.GetBuybackList()
+    };
+
+    $download.attr('href', 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(exportData, null, 2)));
+    $download.attr('download', 'buyback-list.json');
+    $download.attr('type', 'text/json');
+    $download[0].click();
+  };
+
+  /**
+   * Downloads buyback inventory as CSV
+   */
+  HangarXPLOR._callbacks.DownloadBuybackCSV = function(e) {
+    e.preventDefault();
+
+    var fetchedAt = new Date().toISOString();
+    var items = HangarXPLOR.GetBuybackList();
+
+    // CSV header with fetch timestamp as a comment
+    var buffer = "# Fetched: " + fetchedAt + "\n";
+    buffer += "Type,Name,Pledge ID,Last Modified,Contained,Available\n";
+
+    // CSV rows
+    buffer += items.map(function(item) {
+      // Escape quotes in strings
+      var escapeCsv = function(str) {
+        if (str === null || str === undefined) return '""';
+        str = String(str);
+        // Escape double quotes by doubling them
+        str = str.replace(/"/g, '""');
+        return '"' + str + '"';
+      };
+
+      return [
+        escapeCsv(item.type),
+        escapeCsv(item.name),
+        item.pledge_id,
+        escapeCsv(item.last_modified),
+        escapeCsv(item.contained),
+        item.is_available
+      ].join(',');
+    }).join('\n');
+
+    $download.attr('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(buffer));
+    $download.attr('download', 'buyback-list.csv');
+    $download.attr('type', 'text/csv');
+    $download[0].click();
+  };
+
 })();

--- a/src/web_resources/HangarXPLOR.DrawBuybackUI.js
+++ b/src/web_resources/HangarXPLOR.DrawBuybackUI.js
@@ -1,0 +1,200 @@
+
+var HangarXPLOR = HangarXPLOR || {};
+
+// Buyback UI state
+HangarXPLOR._buybackType = 'All';
+HangarXPLOR._buybackSort = 'PledgeId';
+HangarXPLOR._buybackFeature = HangarXPLOR._buybackFeature || {};
+HangarXPLOR._buybackPagerCallbacks = [];
+
+/**
+ * Renders the buyback page UI controls
+ * Styled to match the hangar page UI
+ */
+HangarXPLOR.DrawBuybackUI = function() {
+  // Remove RSI's native pagination FIRST, before we create our own pager-wrapper
+  // This prevents users from accidentally navigating away and losing our enhancements
+  $('.pager-wrapper').remove();
+
+  // Find the controls area - on buyback page it's the form.filters element
+  var $controlsContainer = $('section.available-pledges form.filters');
+
+  if ($controlsContainer.length === 0) {
+    // Fallback - create a controls container before the pledges list
+    $controlsContainer = $('<div>', { class: 'js-custom-controls' });
+    $('section.available-pledges').prepend($controlsContainer);
+  } else {
+    $controlsContainer.addClass('js-custom-controls');
+    $controlsContainer.removeClass('controls');
+    $controlsContainer.empty();
+  }
+
+  var $controls1 = $('<div>', { class: 'controls clearfix mrn15' });
+
+  $controlsContainer.append($controls1);
+
+  // Row 1 (inside .filters): Type filter dropdown and Sort dropdown only
+  $controls1.append(HangarXPLOR.Dropdown([
+    { Value: 'All', Text: 'All Types', Class: 'first', Selected: HangarXPLOR._buybackType == 'All' },
+    { Value: 'Ships', Text: 'Standalone Ships', Selected: HangarXPLOR._buybackType == 'Ships' },
+    { Value: 'Packages', Text: 'Game Packages', Selected: HangarXPLOR._buybackType == 'Packages' },
+    { Value: 'Upgrades', Text: 'Upgrades', Selected: HangarXPLOR._buybackType == 'Upgrades' },
+    { Value: 'Paints', Text: 'Paints', Class: 'split', Selected: HangarXPLOR._buybackType == 'Paints' },
+    { Value: 'AddOns', Text: 'Add-Ons', Selected: HangarXPLOR._buybackType == 'AddOns' },
+    { Value: 'Components', Text: 'Components', Selected: HangarXPLOR._buybackType == 'Components' },
+    { Value: 'Weapons', Text: 'Weapons', Selected: HangarXPLOR._buybackType == 'Weapons' },
+    { Value: 'Decorations', Text: 'Hangar Decorations', Selected: HangarXPLOR._buybackType == 'Decorations' },
+    { Value: 'Subscriber', Text: 'Subscriber Items', Class: 'split', Selected: HangarXPLOR._buybackType == 'Subscriber' },
+    { Value: 'Other', Text: 'Other', Selected: HangarXPLOR._buybackType == 'Other' },
+  ], '170px', 'js-buyback-filter', function(e, value) {
+    HangarXPLOR._buybackType = value;
+    HangarXPLOR.RenderBuyback();
+    HangarXPLOR.RefreshBuybackPager();
+  }));
+
+  $controls1.append(HangarXPLOR.Dropdown([
+    { Value: 'PledgeId', Text: 'Recent First', Selected: HangarXPLOR._buybackSort == 'PledgeId' },
+    { Value: 'Name', Text: 'Name A-Z', Selected: HangarXPLOR._buybackSort == 'Name' },
+    { Value: 'NameDesc', Text: 'Name Z-A', Selected: HangarXPLOR._buybackSort == 'NameDesc' },
+    { Value: 'Type', Text: 'By Type', Selected: HangarXPLOR._buybackSort == 'Type' },
+    { Value: 'Modified', Text: 'Last Modified', Selected: HangarXPLOR._buybackSort == 'Modified' },
+  ], '137px', 'js-buyback-sort', function(e, value) {
+    HangarXPLOR._buybackSort = value;
+    HangarXPLOR.RenderBuyback();
+    HangarXPLOR.RefreshBuybackPager();
+  }));
+
+  // Create a container for pager and search OUTSIDE the .filters form (below the blue line)
+  var $extendedControls = $('<div>', { class: 'js-buyback-extended-controls' });
+  $controlsContainer.after($extendedControls);
+
+  // Pager row (below the blue line)
+  $extendedControls.append(HangarXPLOR.BuybackPager([
+    { Value: '9999', Text: 'Display All', Class: 'first', Selected: HangarXPLOR._buybackPageCount == 9999 },
+    { Value: '10', Text: '10 per page', Selected: HangarXPLOR._buybackPageCount == 10 },
+    { Value: '20', Text: '20 per page', Selected: HangarXPLOR._buybackPageCount == 20 },
+    { Value: '50', Text: '50 per page', Selected: HangarXPLOR._buybackPageCount == 50 },
+    { Value: '100', Text: '100 per page', Selected: HangarXPLOR._buybackPageCount == 100 },
+  ], '130px', 'js-buyback-pager', function() {
+    HangarXPLOR.RenderBuyback();
+  }));
+
+  // Search box
+  var $searchWrapper = $('<div>', { class: 'js-buyback-search-wrapper' });
+  $searchWrapper.append(HangarXPLOR.BuybackSearchBox());
+  $extendedControls.append($searchWrapper);
+
+  // Initial render
+  HangarXPLOR.RenderBuyback();
+  HangarXPLOR.RefreshBuybackBulkUI();
+  HangarXPLOR.RefreshBuybackPager();
+};
+
+/**
+ * Refresh all buyback pager callbacks
+ */
+HangarXPLOR.RefreshBuybackPager = function() {
+  for (var i = 0, j = HangarXPLOR._buybackPagerCallbacks.length; i < j; i++) {
+    HangarXPLOR._buybackPagerCallbacks[i]();
+  }
+};
+
+/**
+ * Creates a pager component for buyback pagination
+ * Styled to match the hangar page pager
+ */
+HangarXPLOR.BuybackPager = function(options, width, className, callback) {
+  width = width || '140px';
+  className = className || 'js-buyback-pager';
+  var maxButtons = 5;
+
+  var $control = $('<div>', { class: 'options-selector pager-wrapper ' + className });
+  var $pager = $('<div>', { class: 'pager clearfix js-pager' });
+  var $left = $('<div>', { class: 'left' });
+  var $right = $('<div>', { class: 'right' });
+
+  $control.append($pager);
+  $pager.append($left, $right);
+
+  HangarXPLOR._buybackPagerCallbacks.push(function() {
+    // Update selected state for dropdown options
+    for (var i = 0, j = options.length; i < j; i++) {
+      options[i].Selected = HangarXPLOR._buybackPageCount == options[i].Value;
+      if (i > 0) options[i].Class = '';
+    }
+
+    var maxPages = Math.ceil(HangarXPLOR._buybackTotalRecords / HangarXPLOR._buybackPageCount);
+    if (HangarXPLOR._buybackPageNo > maxPages) HangarXPLOR._buybackPageNo = Math.max(1, maxPages);
+
+    var firstPage = Math.max(1, HangarXPLOR._buybackPageNo - Math.floor(maxButtons / 2));
+    if (firstPage > maxPages - maxButtons) firstPage = Math.max(1, maxPages - maxButtons + 1);
+
+    $left.empty();
+    $right.empty();
+
+    $left.append(HangarXPLOR.Dropdown(options, width, className, function(e, pageCount) {
+      HangarXPLOR._buybackPageNo = 1;
+      HangarXPLOR._buybackPageCount = parseInt(pageCount) || 20;
+
+      if (typeof callback === 'function') callback.call(this, e, HangarXPLOR._buybackPageNo);
+
+      HangarXPLOR.RefreshBuybackPager();
+    }));
+
+    if (maxPages <= 1) {
+      $left.addClass('mr5');
+      return;
+    } else {
+      $left.removeClass('mr5');
+    }
+
+    // Render page number buttons
+    for (var p = firstPage, pMax = Math.min(firstPage + maxButtons - 1, maxPages); p <= pMax; p++) {
+      $right.append($('<a>', {
+        class: 'trans-02s trans-color' + ((p == HangarXPLOR._buybackPageNo) ? ' active' : ''),
+        rel: p,
+        text: p,
+        href: '#'
+      }));
+    }
+
+    var $buttons = $('a', $right);
+    $buttons.bind('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      var $this = $(this);
+      var newPage = parseInt($this.attr('rel'));
+
+      if (newPage != HangarXPLOR._buybackPageNo) {
+        HangarXPLOR._buybackPageNo = newPage;
+
+        if (typeof callback === 'function') callback.call(this, e, HangarXPLOR._buybackPageNo);
+
+        HangarXPLOR.RefreshBuybackPager();
+      }
+    });
+  });
+
+  return $control;
+};
+
+/**
+ * Creates a search box for buyback page
+ * Styled to match the hangar page search box
+ */
+HangarXPLOR.BuybackSearchBox = function() {
+  var $searchBox = $('<input>', {
+    id: 'buybackSearchInput',
+    class: 'js-custom-search',
+    placeholder: 'Search'
+  });
+
+  $searchBox.on('keyup', function() {
+    HangarXPLOR._buybackSearchTerm = $(this).val();
+    HangarXPLOR.RenderBuyback();
+    HangarXPLOR.RefreshBuybackPager();
+  });
+
+  return $searchBox;
+};

--- a/src/web_resources/HangarXPLOR.FilterBuyback.js
+++ b/src/web_resources/HangarXPLOR.FilterBuyback.js
@@ -1,0 +1,114 @@
+
+var HangarXPLOR = HangarXPLOR || {};
+
+/**
+ * Filters buyback inventory based on filter type
+ * @param {Array} list - Array of buyback pledge items to filter
+ * @param {string} filterType - The filter type to apply
+ * @returns {Array} Filtered array of buyback pledge items
+ */
+HangarXPLOR.FilterBuyback = function(list, filterType) {
+  switch(filterType) {
+    // Type filters
+    case 'All':
+    case '':
+      return list;
+
+    case 'Ships':
+      return $.grep(list, function(item) { return item.filters.is_ship; });
+
+    case 'Paints':
+      return $.grep(list, function(item) { return item.filters.is_paint; });
+
+    case 'AddOns':
+      return $.grep(list, function(item) { return item.filters.is_addon; });
+
+    case 'Upgrades':
+      return $.grep(list, function(item) { return item.filters.is_upgrade; });
+
+    case 'Packages':
+      return $.grep(list, function(item) { return item.filters.is_package; });
+
+    case 'Subscriber':
+      return $.grep(list, function(item) { return item.filters.is_subscriber || item.filters.is_flair; });
+
+    case 'Components':
+      return $.grep(list, function(item) { return item.filters.is_component; });
+
+    case 'Weapons':
+      return $.grep(list, function(item) { return item.filters.is_weapon; });
+
+    case 'Decorations':
+      return $.grep(list, function(item) { return item.filters.is_hangar_decoration; });
+
+    case 'Other':
+      return $.grep(list, function(item) {
+        return !item.filters.is_ship &&
+               !item.filters.is_paint &&
+               !item.filters.is_addon &&
+               !item.filters.is_upgrade &&
+               !item.filters.is_package &&
+               !item.filters.is_component &&
+               !item.filters.is_weapon &&
+               !item.filters.is_hangar_decoration &&
+               !item.filters.is_subscriber &&
+               !item.filters.is_flair;
+      });
+
+    default:
+      return list;
+  }
+};
+
+/**
+ * Sorts buyback inventory
+ * @param {Array} list - Array of buyback pledge items to sort
+ * @param {string} sortType - The sort type to apply
+ * @returns {Array} Sorted array of buyback pledge items
+ */
+HangarXPLOR.SortBuyback = function(list, sortType) {
+  var sorted = list.slice(); // Copy array
+
+  switch(sortType) {
+    case 'Name':
+      sorted.sort(function(a, b) {
+        return a.sortName.localeCompare(b.sortName);
+      });
+      break;
+
+    case 'NameDesc':
+      sorted.sort(function(a, b) {
+        return b.sortName.localeCompare(a.sortName);
+      });
+      break;
+
+    case 'Type':
+      sorted.sort(function(a, b) {
+        return a.buyback_type.localeCompare(b.buyback_type) || a.sortName.localeCompare(b.sortName);
+      });
+      break;
+
+    case 'Modified':
+      sorted.sort(function(a, b) {
+        // Parse dates for comparison (format: "December 02, 2025")
+        var dateA = new Date(a.last_modified);
+        var dateB = new Date(b.last_modified);
+        return dateB - dateA; // Most recent first
+      });
+      break;
+
+    case 'PledgeId':
+      sorted.sort(function(a, b) {
+        return b.pledge_id - a.pledge_id; // Highest ID first (most recent purchases)
+      });
+      break;
+
+    default:
+      // Default: most recent pledge ID first
+      sorted.sort(function(a, b) {
+        return b.pledge_id - a.pledge_id;
+      });
+  }
+
+  return sorted;
+};

--- a/src/web_resources/HangarXPLOR.LoadBuybackCache.js
+++ b/src/web_resources/HangarXPLOR.LoadBuybackCache.js
@@ -1,0 +1,49 @@
+
+var HangarXPLOR = HangarXPLOR || {};
+
+/**
+ * Loads buyback pledges from cache if available and valid
+ * Uses separate cache keys prefixed with 'buyback:' to avoid conflicts with hangar cache
+ * @param {function} callback - Function to call if cache is invalid/missing
+ */
+HangarXPLOR.LoadBuybackCache = function(callback) {
+  HangarXPLOR.Log('Load Buyback Cache');
+
+  chrome.storage.local.get(null, function(cache) {
+
+    if (HangarXPLOR._buybackCacheHash == HangarXPLOR._buybackActiveHash &&
+        cache['buyback:cache:hash'] == HangarXPLOR._buybackCacheHash &&
+        cache['buyback:cache:count'] > 0)
+    {
+      HangarXPLOR._fromCache = true;
+
+      HangarXPLOR.Log('Using buyback cache with', cache['buyback:cache:count'], 'items');
+
+      for (var i = 0; i < cache['buyback:cache:count']; i++) {
+        HangarXPLOR.ParseBuybackPledge.apply($(cache['buyback:cache:' + i])[0]);
+      }
+
+      HangarXPLOR.DrawBuybackUI();
+      return;
+    }
+
+    HangarXPLOR.Log('Buyback cache invalid or missing, loading fresh data');
+    HangarXPLOR._fromCache = false;
+
+    // Reset counts before loading fresh data
+    HangarXPLOR._buybackCounts = {
+      total: 0,
+      ships: 0,
+      paints: 0,
+      upgrades: 0,
+      packages: 0,
+      addons: 0,
+      subscriber: 0,
+      other: 0,
+      available: 0,
+      unavailable: 0
+    };
+
+    if (typeof callback === 'function') callback.call(this);
+  });
+};

--- a/src/web_resources/HangarXPLOR.LoadBuybackPage.js
+++ b/src/web_resources/HangarXPLOR.LoadBuybackPage.js
@@ -1,0 +1,28 @@
+
+var HangarXPLOR = HangarXPLOR || {};
+
+/**
+ * Loads a page of buyback pledges via AJAX
+ * @param {number} pageNo - The page number to load (1-indexed)
+ */
+HangarXPLOR.LoadBuybackPage = function(pageNo) {
+  pageNo = pageNo || 1;
+
+  HangarXPLOR.Log('Loading buyback page', pageNo);
+  HangarXPLOR.UpdateStatus(pageNo);
+
+  $.ajax({
+    url: '/account/buy-back-pledges?page=' + pageNo + '&pagesize=50',
+    method: 'GET',
+    dataType: 'html',
+    success: function(response) {
+      HangarXPLOR.ProcessBuybackPage($(response), pageNo);
+    },
+    error: function(xhr, status, error) {
+      HangarXPLOR.Log('Error loading buyback page', pageNo, status, error);
+      // Still try to render what we have
+      HangarXPLOR.SaveBuybackCache();
+      HangarXPLOR.DrawBuybackUI();
+    }
+  });
+};

--- a/src/web_resources/HangarXPLOR.LoadSettings.js
+++ b/src/web_resources/HangarXPLOR.LoadSettings.js
@@ -13,6 +13,7 @@ HangarXPLOR.LoadSettings = function(callback)
     HangarXPLOR._pageCount          = settings._pageCount || 10;
     HangarXPLOR._logEnabled         = settings._logEnabled || false;
     HangarXPLOR._cacheHash          = settings._cacheHash || 0;
+    HangarXPLOR._buybackCacheHash   = settings._buybackCacheHash || 0;
     HangarXPLOR._cacheSalt          = settings._cacheSalt || btoa(Math.random());
     
     HangarXPLOR._feature            = HangarXPLOR._feature       || {};

--- a/src/web_resources/HangarXPLOR.ParseBuybackPledge.js
+++ b/src/web_resources/HangarXPLOR.ParseBuybackPledge.js
@@ -1,0 +1,85 @@
+
+var HangarXPLOR = HangarXPLOR || {};
+
+/**
+ * Parses a buyback pledge item from the DOM
+ * Called with 'this' context set to the pledge <li> element
+ */
+HangarXPLOR.ParseBuybackPledge = function() {
+  // Cache raw HTML for later caching
+  if (HangarXPLOR._fromCache != true) {
+    HangarXPLOR._buybackRaw.push(this.outerHTML);
+  }
+
+  // Initialize filters object
+  this.filters = {};
+
+  // Parse title: "Type - Name" from h1 element
+  var title = $('h1', this).text().trim();
+  var dashIndex = title.indexOf(' - ');
+  this.buyback_type = dashIndex > -1 ? title.substring(0, dashIndex).trim() : 'Unknown';
+  this.buyback_name = dashIndex > -1 ? title.substring(dashIndex + 3).trim() : title;
+
+  // Normalize type names to standard plural forms (matching dropdown options)
+  var typeNormalization = {
+    'Standalone Ship': 'Standalone Ships',
+    'Upgrade': 'Upgrades',
+    'Package': 'Game Packages',
+    'Component': 'Components',
+    'Weapon': 'Weapons'
+  };
+  if (typeNormalization[this.buyback_type]) {
+    this.buyback_type = typeNormalization[this.buyback_type];
+  }
+
+  // Parse last modified date from dl
+  var $dl = $('dl', this);
+  var $lastModifiedDt = $dl.find('dt').filter(function() {
+    return $(this).text().trim() === 'Last Modified';
+  });
+  this.last_modified = $lastModifiedDt.next('dd').text().trim();
+
+  // Parse contained items from dl
+  var $containedDt = $dl.find('dt').filter(function() {
+    return $(this).text().trim() === 'Contained';
+  });
+  this.contained = $containedDt.next('dd').text().trim();
+
+  // Parse pledge ID from buyback link
+  var $buybackLink = $('a.holosmallbtn', this);
+  var href = $buybackLink.attr('href') || '';
+  var match = href.match(/\/pledge\/buyback\/(\d+)/);
+  this.pledge_id = match ? parseInt(match[1]) : 0;
+
+  // Set filter flags based on type (types are already normalized to standard forms)
+  this.filters.is_ship = this.buyback_type === 'Standalone Ships';
+  this.filters.is_paint = this.buyback_type === 'Paints';
+  this.filters.is_addon = this.buyback_type === 'Add-Ons';
+  this.filters.is_subscriber = this.buyback_type.indexOf('Subscribers') > -1;
+  this.filters.is_upgrade = this.buyback_type === 'Upgrades';
+  this.filters.is_package = this.buyback_type === 'Game Packages';
+  this.filters.is_component = this.buyback_type === 'Components';
+  this.filters.is_weapon = this.buyback_type === 'Weapons';
+  this.filters.is_hangar_decoration = this.buyback_type === 'Hangar Decorations';
+  this.filters.is_flair = this.buyback_type === 'Subscriber Flair';
+
+  // For sorting and display
+  this.sortName = this.buyback_name.toLowerCase();
+  this.displayName = this.buyback_type + ' - ' + this.buyback_name;
+
+  // Update counts
+  HangarXPLOR._buybackCounts.total++;
+  if (this.filters.is_ship) HangarXPLOR._buybackCounts.ships++;
+  else if (this.filters.is_paint) HangarXPLOR._buybackCounts.paints++;
+  else if (this.filters.is_upgrade) HangarXPLOR._buybackCounts.upgrades++;
+  else if (this.filters.is_package) HangarXPLOR._buybackCounts.packages++;
+  else if (this.filters.is_addon) HangarXPLOR._buybackCounts.addons++;
+  else if (this.filters.is_component) HangarXPLOR._buybackCounts.components++;
+  else if (this.filters.is_weapon) HangarXPLOR._buybackCounts.weapons++;
+  else if (this.filters.is_hangar_decoration) HangarXPLOR._buybackCounts.decorations++;
+  else if (this.filters.is_subscriber || this.filters.is_flair) HangarXPLOR._buybackCounts.subscriber++;
+  else HangarXPLOR._buybackCounts.other++;
+
+  // Add to buyback inventory
+  HangarXPLOR._buybackInventory.push(this);
+};

--- a/src/web_resources/HangarXPLOR.ProcessBuybackPage.js
+++ b/src/web_resources/HangarXPLOR.ProcessBuybackPage.js
@@ -1,0 +1,37 @@
+
+var HangarXPLOR = HangarXPLOR || {};
+
+/**
+ * Processes a loaded buyback page, parsing each pledge and handling pagination
+ * @param {jQuery} $page - jQuery object containing the loaded page HTML
+ * @param {number} pageNo - The current page number
+ */
+HangarXPLOR.ProcessBuybackPage = function($page, pageNo) {
+  // Find pledges list - selector: section.available-pledges ul.pledges > li
+  var $items = $('section.available-pledges ul.pledges > li', $page);
+
+  HangarXPLOR.Log('Processing buyback page', pageNo, 'with', $items.length, 'items');
+
+  // Check for empty page
+  if ($items.length === 0) {
+    HangarXPLOR.Log('No items found on buyback page', pageNo, '- finished loading');
+    HangarXPLOR.SaveBuybackCache();
+    HangarXPLOR.DrawBuybackUI();
+    return;
+  }
+
+  // Parse each item
+  $items.each(function() {
+    HangarXPLOR.ParseBuybackPledge.apply(this);
+  });
+
+  // Continue loading if we got a full page (50 items)
+  // This indicates there may be more pages
+  if ($items.length >= 50) {
+    HangarXPLOR.LoadBuybackPage(pageNo + 1);
+  } else {
+    HangarXPLOR.Log('Buyback loading complete. Total items:', HangarXPLOR._buybackInventory.length);
+    HangarXPLOR.SaveBuybackCache();
+    HangarXPLOR.DrawBuybackUI();
+  }
+};

--- a/src/web_resources/HangarXPLOR.RenderBuyback.js
+++ b/src/web_resources/HangarXPLOR.RenderBuyback.js
@@ -1,0 +1,95 @@
+
+var HangarXPLOR = HangarXPLOR || {};
+
+HangarXPLOR._buybackPageNo = 1;
+HangarXPLOR._buybackPageCount = 20;
+HangarXPLOR._buybackTotalRecords = 0;
+HangarXPLOR._buybackSearchTerm = '';
+HangarXPLOR._buybackPagerCallbacks = HangarXPLOR._buybackPagerCallbacks || [];
+
+// Default RefreshBuybackPager - will be called by callbacks set up in DrawBuybackUI
+HangarXPLOR.RefreshBuybackPager = HangarXPLOR.RefreshBuybackPager || function() {
+  for (var i = 0, j = HangarXPLOR._buybackPagerCallbacks.length; i < j; i++) {
+    HangarXPLOR._buybackPagerCallbacks[i]();
+  }
+};
+
+/**
+ * Renders buyback items that match the search, filter and sort criteria
+ */
+HangarXPLOR.RenderBuyback = function() {
+  var filterBy = 'js-buyback-filter';
+  var sortBy = 'js-buyback-sort';
+  var searchBy = 'js-custom-search';  // Uses shared search class like hangar page
+
+  HangarXPLOR.Log('Rendering buyback', filterBy, sortBy, searchBy, HangarXPLOR._buybackPageNo, HangarXPLOR._buybackPageCount);
+
+  filterBy = '.' + filterBy;
+  sortBy = '.' + sortBy;
+  searchBy = '#buybackSearchInput';  // Use ID for buyback search to avoid conflict with hangar
+
+  var buffer = HangarXPLOR._buybackInventory;
+
+  // Apply filters
+  $(filterBy).each(function() {
+    buffer = HangarXPLOR.FilterBuyback(buffer, $(this).val());
+  });
+
+  // Apply search
+  $(searchBy).each(function() {
+    var searchTerm = $(this).val();
+    if (searchTerm && searchTerm.trim().length > 0) {
+      HangarXPLOR._buybackSearchTerm = searchTerm.toLowerCase();
+      buffer = $.grep(buffer, function(item) {
+        return item.buyback_name.toLowerCase().indexOf(HangarXPLOR._buybackSearchTerm) > -1 ||
+               item.buyback_type.toLowerCase().indexOf(HangarXPLOR._buybackSearchTerm) > -1 ||
+               item.contained.toLowerCase().indexOf(HangarXPLOR._buybackSearchTerm) > -1;
+      });
+    }
+  });
+
+  // Apply sort
+  $(sortBy).each(function() {
+    buffer = HangarXPLOR.SortBuyback(buffer, $(this).val());
+  });
+
+  HangarXPLOR._buybackFiltered = buffer;
+
+  // User performed search & no results
+  if (
+    HangarXPLOR._buybackInventory.length > 0 &&
+    buffer.length === 0 &&
+    HangarXPLOR._buybackSearchTerm.length !== 0
+  ) {
+    var $noResults = $('<li>').append(
+      $('<h4>', { class: 'empty-list', text: 'Your search returned no results.' })
+    );
+    buffer = [$noResults[0]];
+  }
+  // Empty Buffer
+  else if (buffer.length == 0) {
+    var $empty = $('<li>').append(
+      $('<h4>', { class: 'empty-list', text: 'Your buyback queue is empty.' })
+    );
+    buffer = [$empty[0]];
+  }
+
+  HangarXPLOR._buybackTotalRecords = buffer.length;
+
+  var maxPages = Math.ceil(HangarXPLOR._buybackTotalRecords / HangarXPLOR._buybackPageCount);
+  if (HangarXPLOR._buybackPageNo > maxPages) HangarXPLOR._buybackPageNo = Math.max(1, maxPages);
+
+  // Apply pagination
+  if (HangarXPLOR._buybackPageCount < 1000) {
+    buffer = buffer.slice(
+      (HangarXPLOR._buybackPageNo - 1) * HangarXPLOR._buybackPageCount,
+      HangarXPLOR._buybackPageNo * HangarXPLOR._buybackPageCount
+    );
+  }
+
+  HangarXPLOR.$list.empty();
+  HangarXPLOR.$list.append(buffer);
+
+  // Update pager display (uses callback system defined in DrawBuybackUI.js)
+  HangarXPLOR.RefreshBuybackPager();
+};

--- a/src/web_resources/HangarXPLOR.SaveBuybackCache.js
+++ b/src/web_resources/HangarXPLOR.SaveBuybackCache.js
@@ -20,6 +20,11 @@ HangarXPLOR.SaveBuybackCache = function(callback) {
   cacheItems['buyback:cache:count'] = HangarXPLOR._buybackRaw.length;
   cacheItems['buyback:cache:hash'] = HangarXPLOR._buybackActiveHash;
 
+  HangarXPLOR._buybackCacheHash = HangarXPLOR._buybackActiveHash;
+
+  // Clean up raw array
+  delete HangarXPLOR._buybackRaw;
+
   // Clear only buyback-related cache keys, not all storage
   chrome.storage.local.get(null, function(existingCache) {
     var keysToRemove = [];
@@ -34,19 +39,16 @@ HangarXPLOR.SaveBuybackCache = function(callback) {
     // Remove old buyback cache keys
     if (keysToRemove.length > 0) {
       chrome.storage.local.remove(keysToRemove, function() {
-        // Save new buyback cache
-        chrome.storage.local.set(cacheItems);
+        // Save new buyback cache, then persist settings
+        chrome.storage.local.set(cacheItems, function() {
+          HangarXPLOR.SaveSettings(callback);
+        });
       });
     } else {
-      // No old keys to remove, just save
-      chrome.storage.local.set(cacheItems);
+      // No old keys to remove, just save and persist settings
+      chrome.storage.local.set(cacheItems, function() {
+        HangarXPLOR.SaveSettings(callback);
+      });
     }
   });
-
-  HangarXPLOR._buybackCacheHash = HangarXPLOR._buybackActiveHash;
-
-  // Clean up raw array
-  delete HangarXPLOR._buybackRaw;
-
-  if (typeof callback === 'function') callback.call(this);
 };

--- a/src/web_resources/HangarXPLOR.SaveBuybackCache.js
+++ b/src/web_resources/HangarXPLOR.SaveBuybackCache.js
@@ -1,0 +1,52 @@
+
+var HangarXPLOR = HangarXPLOR || {};
+
+/**
+ * Saves buyback pledges to cache
+ * Uses separate cache keys prefixed with 'buyback:' to avoid conflicts with hangar cache
+ * @param {function} callback - Optional callback function
+ */
+HangarXPLOR.SaveBuybackCache = function(callback) {
+  if (HangarXPLOR._fromCache == true) return;
+
+  HangarXPLOR.Log('Saving buyback cache with', HangarXPLOR._buybackRaw.length, 'items');
+
+  var cacheItems = {};
+
+  $.each(HangarXPLOR._buybackRaw, function(index, item) {
+    cacheItems['buyback:cache:' + index] = item;
+  });
+
+  cacheItems['buyback:cache:count'] = HangarXPLOR._buybackRaw.length;
+  cacheItems['buyback:cache:hash'] = HangarXPLOR._buybackActiveHash;
+
+  // Clear only buyback-related cache keys, not all storage
+  chrome.storage.local.get(null, function(existingCache) {
+    var keysToRemove = [];
+
+    // Find existing buyback cache keys to remove
+    for (var key in existingCache) {
+      if (key.indexOf('buyback:cache:') === 0) {
+        keysToRemove.push(key);
+      }
+    }
+
+    // Remove old buyback cache keys
+    if (keysToRemove.length > 0) {
+      chrome.storage.local.remove(keysToRemove, function() {
+        // Save new buyback cache
+        chrome.storage.local.set(cacheItems);
+      });
+    } else {
+      // No old keys to remove, just save
+      chrome.storage.local.set(cacheItems);
+    }
+  });
+
+  HangarXPLOR._buybackCacheHash = HangarXPLOR._buybackActiveHash;
+
+  // Clean up raw array
+  delete HangarXPLOR._buybackRaw;
+
+  if (typeof callback === 'function') callback.call(this);
+};

--- a/src/web_resources/HangarXPLOR.SaveSettings.js
+++ b/src/web_resources/HangarXPLOR.SaveSettings.js
@@ -13,6 +13,7 @@ HangarXPLOR.SaveSettings = function(callback)
   settings._pageCount          = HangarXPLOR._pageCount || 10;
   settings._logEnabled         = HangarXPLOR._logEnabled || false;
   settings._cacheHash          = HangarXPLOR._cacheHash || 0;
+  settings._buybackCacheHash   = HangarXPLOR._buybackCacheHash || 0;
   settings._cacheSalt          = HangarXPLOR._cacheSalt || btoa(Math.random());
   
   settings._feature_LTI        = HangarXPLOR._feature.LTI      || '';

--- a/src/web_resources/HangarXPLOR.css
+++ b/src/web_resources/HangarXPLOR.css
@@ -31,6 +31,32 @@
 .js-bulk-ui .loading .value { display: none; }
 .js-bulk-ui .loading .status { display: block; }
 
+/* Buyback summary panel styles */
+.js-buyback-bulk-ui .buyback-summary-row { margin-bottom: 10px; }
+.js-buyback-bulk-ui .buyback-summary-row .amount { margin-right: 8px; }
+.js-buyback-bulk-ui .buyback-summary-row .label { width: auto; }
+
+.js-buyback-bulk-ui .buyback-type-breakdown { display: flex; flex-direction: column; gap: 2px; margin: 8px 0; }
+.js-buyback-bulk-ui .buyback-count-row { display: flex; align-items: baseline; }
+.js-buyback-bulk-ui .buyback-count-row .count-num { color: #25e4ff; font-size: 16px; font-family: 'Electrolize'; min-width: 35px; text-align: right; margin-right: 8px; }
+.js-buyback-bulk-ui .buyback-count-row .count-label { color: #6c84a2; font-size: 10px; text-transform: uppercase; font-family: 'Electrolize'; }
+
+/* Buyback extended controls (pager + search, below the blue line) */
+.js-buyback-extended-controls { margin-bottom: 15px; }
+.js-buyback-extended-controls .pager-wrapper { margin-bottom: 10px; }
+.js-buyback-extended-controls .pager .right { float: right; }
+.js-buyback-extended-controls .selectlist > span { width: 75%; }
+
+/* Buyback search styles */
+.js-buyback-search-wrapper { position: relative; margin: 0; display: block; width: 100%; }
+.js-buyback-search-wrapper .js-custom-search { border: 1px solid rgba(22, 42, 63, 0.8); font-size: 12px; color: #387893; width: 100%; padding: 10px 15px; display: block; box-sizing: border-box; transition: all 0.2s; background: rgba(0,0,0,0.2); position: static; }
+.js-buyback-search-wrapper .js-custom-search:focus { border: 1px solid #00B7CA; color: #42C6E7; box-shadow: inset 0 0 20px rgba(0,112,200,0.3); outline: none; }
+.js-buyback-search-wrapper .js-custom-search::placeholder { color: #355e78; }
+
+/* Ensure pledges list clears the controls */
+.available-pledges ul.pledges { clear: both; }
+.js-buyback-inventory { margin-top: 10px; }
+
 .js-custom-controls .controls.js-custom-search-wrapper { position: relative; margin: -10px 0px 0px 10px; padding: 0 0 5px; height: 35px !important; }
 .js-custom-controls .js-custom-search,
 .js-custom-controls .js-custom-search-complete { border: 1px solid rgba(22, 42, 63, 0.8); font-size: 12px; color: #355e78; width: 100%; padding: 10px 15px; display: block; -moz-box-sizing: border-box; box-sizing: border-box; -webkit-transition: all 0.2s !important; -moz-transition: all 0.2s !important; -o-transition: all 0.2s !important; -ms-transition: all 0.2s !important; transition: all 0.2s !important; position: absolute; top: 0; left: 0; z-index: 11; background: transparent; }

--- a/src/web_resources/HangarXPLOR.js
+++ b/src/web_resources/HangarXPLOR.js
@@ -12,6 +12,27 @@ HangarXPLOR._ltiCount      = HangarXPLOR._ltiCount || 0;
 HangarXPLOR._cacheSalt     = HangarXPLOR._cacheSalt || btoa(Math.random());
 HangarXPLOR._initCount     = HangarXPLOR._initCount || 0;
 
+// Page type detection
+HangarXPLOR._pageType = window.location.pathname.includes('buy-back-pledges') ? 'buyback' : 'hangar';
+
+// Buyback-specific state variables
+HangarXPLOR._buybackInventory = [];                  // Inventory containing all buyback pledges
+HangarXPLOR._buybackFiltered = [];                   // Filtered buyback pledges for display
+HangarXPLOR._buybackRaw = [];                        // Raw HTML for buyback caching
+HangarXPLOR._buybackCounts = {                       // Type counts for summary panel
+  total: 0,
+  ships: 0,
+  paints: 0,
+  upgrades: 0,
+  packages: 0,
+  addons: 0,
+  components: 0,
+  weapons: 0,
+  decorations: 0,
+  subscriber: 0,
+  other: 0
+};
+
 var RSI = RSI || {};
 
 HangarXPLOR.Initialize = function()
@@ -80,31 +101,56 @@ HangarXPLOR.Initialize = function()
         });
       
       HangarXPLOR.LoadSettings(function() {
-        var $lists = $('.list-items');
-        
-        if ($lists.length == 1) {
-          HangarXPLOR.BulkUI();
-          HangarXPLOR.$list = $($lists[0]);
-          HangarXPLOR.$list.addClass('js-inventory');
-          $lists = undefined;
-          
-          HangarXPLOR.UpdateStatus(0);
-          
-          RSI.Api.Account.pledgeLog((payload) => {
-    
+
+        // Branch based on page type
+        if (HangarXPLOR._pageType === 'buyback') {
+          // Buyback page initialization
+          var $pledgesList = $('section.available-pledges ul.pledges');
+
+          if ($pledgesList.length >= 1) {
+            HangarXPLOR.BuybackBulkUI();
+            HangarXPLOR.$list = $($pledgesList[0]);
+            HangarXPLOR.$list.addClass('js-buyback-inventory');
+
+            HangarXPLOR.UpdateStatus(0);
+
+            // Generate a simple hash based on current timestamp for buyback cache
+            // Buyback pages don't have the same pledgeLog API
             var today = new Date().toISOString();
-            var safetySalt = '';
-    
-            // CIG Released ship naming in March 2021, which requires us to invalidate cache
-            if (today.substr(0, 7) == '2021-03') safetySalt = today.substr(0, 13) + ':';
-    
-            HangarXPLOR._activeHash = safetySalt + payload.data.rendered.length + ':' + btoa(payload.data.rendered.substr(39, 20)) + ':' + HangarXPLOR._cacheSalt;
-            
-            HangarXPLOR.LoadCache(HangarXPLOR.LoadPage);
-          });
-          
+            HangarXPLOR._buybackActiveHash = today.substr(0, 10) + ':' + HangarXPLOR._cacheSalt;
+
+            HangarXPLOR.LoadBuybackCache(HangarXPLOR.LoadBuybackPage);
+          } else {
+            HangarXPLOR.Log('Error locating buyback pledges list');
+          }
         } else {
-          HangarXPLOR.Log('Error locating inventory');
+          // Hangar page initialization (existing code)
+          var $lists = $('.list-items');
+
+          if ($lists.length == 1) {
+            HangarXPLOR.BulkUI();
+            HangarXPLOR.$list = $($lists[0]);
+            HangarXPLOR.$list.addClass('js-inventory');
+            $lists = undefined;
+
+            HangarXPLOR.UpdateStatus(0);
+
+            RSI.Api.Account.pledgeLog((payload) => {
+
+              var today = new Date().toISOString();
+              var safetySalt = '';
+
+              // CIG Released ship naming in March 2021, which requires us to invalidate cache
+              if (today.substr(0, 7) == '2021-03') safetySalt = today.substr(0, 13) + ':';
+
+              HangarXPLOR._activeHash = safetySalt + payload.data.rendered.length + ':' + btoa(payload.data.rendered.substr(39, 20)) + ':' + HangarXPLOR._cacheSalt;
+
+              HangarXPLOR.LoadCache(HangarXPLOR.LoadPage);
+            });
+
+          } else {
+            HangarXPLOR.Log('Error locating inventory');
+          }
         }
       });
     }


### PR DESCRIPTION
## Summary

Extends HangarXPLOR to enhance the RSI Buyback Pledges page with filtering, sorting, search, and export capabilities.

## Changes

- **Buyback page enhancements**: Pre-load all pages, filter by type (Ships, Packages, Upgrades, Paints, Add-Ons, Components, Weapons, Decorations, Subscriber Items), sort by name/type/date, search across items
- **Pagination controls**: Custom pager matching hangar page style with items-per-page dropdown and page buttons
- **Summary panel**: Shows total item counts by category
- **Export support**: JSON and CSV export for buyback items
- **Caching**: Local storage caching for faster subsequent loads
- **Type normalization**: Standardized type names (e.g., "Standalone Ship" → "Standalone Ships") for consistent exports
- **UI polish**: Removed RSI's native pagination to prevent accidental page navigation, styled controls to match site theme

## Files Added

- `HangarXPLOR.DrawBuybackUI.js` - UI controls rendering
- `HangarXPLOR.FilterBuyback.js` - Filtering and sorting logic
- `HangarXPLOR.RenderBuyback.js` - Display rendering
- `HangarXPLOR.ParseBuybackPledge.js` - DOM parsing
- `HangarXPLOR.BuybackBulkUI.js` - Summary panel
- `HangarXPLOR.LoadBuybackPage.js` / `LoadBuybackCache.js` / `SaveBuybackCache.js` - Data loading and caching
- `HangarXPLOR.ProcessBuybackPage.js` - Page processing

Resolves #25, resolves #67