### PR TITLE
feat(trusted sites): allows users to add trusted sites at their discretion

### DIFF
--- a/src/content_scripts/trusted-site-relay.js
+++ b/src/content_scripts/trusted-site-relay.js
@@ -1,0 +1,76 @@
+// Registered via chrome.scripting.registerContentScripts for each origin the user has added to their Trusted Sites 
+// list. Runs at document_start on those pages. Its entire job:
+// 1. Listen for window.postMessage events of shape { type: 'HangarXPLOR:request', requestId }
+// 2. Read the most recent hangar snapshot from chrome.storage.local.
+// 3. Reply via window.postMessage with { type: 'HangarXPLOR:response', requestId, status, data }
+
+(function() {
+    'use strict';
+
+    var TRUSTED_SITES_KEY = '_setting_TrustedSites';
+    var SNAPSHOT_KEY      = 'cache:parsed_export';
+    var MSG_REQUEST       = 'HangarXPLOR:request';
+    var MSG_RESPONSE      = 'HangarXPLOR:response';
+
+    function currentOriginPattern() {
+        var hostname = window.location.hostname;
+        var protocol = window.location.protocol;
+        if (hostname.length === 0) return null;
+        if (protocol === 'https:') return 'https://' + hostname + '/*';
+        if (protocol === 'http:' && hostname === 'localhost') return 'http://localhost/*';
+        return null;
+    }
+
+    function isCurrentOriginTrusted(callback) {
+        var pattern = currentOriginPattern();
+        if (pattern === null) { callback(false); return; }
+        var query = {};
+        query[TRUSTED_SITES_KEY] = [];
+        chrome.storage.sync.get(query, function(settings) {
+            var sites = settings[TRUSTED_SITES_KEY] || [];
+            callback(sites.indexOf(pattern) !== -1);
+        });
+    }
+
+    function readSnapshot(callback) {
+        chrome.storage.local.get(SNAPSHOT_KEY, function(items) {
+            callback(items[SNAPSHOT_KEY] || null);
+        });
+    }
+
+    function respond(requestId, status, payload) {
+        var message = { type: MSG_RESPONSE, requestId: requestId, status: status };
+        if (status === 'ok') {
+            message.data = payload;
+        } else {
+            message.error = payload;
+        }
+        window.postMessage(message, window.location.origin);
+    }
+
+    window.addEventListener('message', function(event) {
+        if (event.source !== window) return;
+
+        var data = event.data;
+        if (!data || typeof data !== 'object') return;
+        if (data.type !== MSG_REQUEST) return;
+        if (typeof data.requestId !== 'string' || data.requestId.length === 0) return;
+
+        var requestId = data.requestId;
+
+        isCurrentOriginTrusted(function(trusted) {
+            if (!trusted) {
+                respond(requestId, 'error', 'not_trusted');
+                return;
+            }
+
+            readSnapshot(function(snapshot) {
+                if (!snapshot) {
+                    respond(requestId, 'error', 'no_data');
+                    return;
+                }
+                respond(requestId, 'ok', snapshot);
+            });
+        });
+    });
+})();

--- a/src/manifest.core.json
+++ b/src/manifest.core.json
@@ -10,7 +10,8 @@
   "manifest_version": 3,
   "permissions": [
       "storage",
-      "unlimitedStorage"
+      "unlimitedStorage",
+      "scripting"
   ],
   "host_permissions": [
       "https://robertsspaceindustries.com/*",

--- a/src/manifest.core.json
+++ b/src/manifest.core.json
@@ -16,6 +16,11 @@
       "https://robertsspaceindustries.com/*",
       "https://www.robertsspaceindustries.com/*"
   ],
+  "optional_host_permissions": [
+      "https://*/*",
+      "http://localhost/*",
+      "https://localhost/*"
+  ],
   "action": {
       "default_icon": {
           "48": "icons/icon_48-fill.png",

--- a/src/manifest.core.json
+++ b/src/manifest.core.json
@@ -8,6 +8,11 @@
     "128": "icons/icon_128.png"
   },
   "manifest_version": 3,
+  "browser_specific_settings": {
+      "gecko": {
+          "id": "hangarxplor@extension"
+      }
+  },
   "permissions": [
       "storage",
       "unlimitedStorage",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,8 @@
   "manifest_version": 3,
   "permissions": [
       "storage",
-      "unlimitedStorage"
+      "unlimitedStorage",
+      "scripting"
   ],
   "host_permissions": [
       "https://robertsspaceindustries.com/*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,6 +16,11 @@
       "https://robertsspaceindustries.com/*",
       "https://www.robertsspaceindustries.com/*"
   ],
+  "optional_host_permissions": [
+      "https://*/*",
+      "http://localhost/*",
+      "https://localhost/*"
+  ],
   "action": {
       "default_icon": {
           "48": "icons/icon_48-fill.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,6 +8,11 @@
     "128": "icons/icon_128.png"
   },
   "manifest_version": 3,
+  "browser_specific_settings": {
+      "gecko": {
+          "id": "hangarxplor@extension"
+      }
+  },
   "permissions": [
       "storage",
       "unlimitedStorage",

--- a/src/ui_resources/HangarXPLOR.Settings.html
+++ b/src/ui_resources/HangarXPLOR.Settings.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <title>HangarXPLOR Settings</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -218,6 +219,107 @@
         transform: translateX(16px);
         background: #25e4ff;
       }
+
+      /* ── Trusted sites ───────────────────────────────────── */
+      .trusted-add {
+        display: flex;
+        gap: 6px;
+        margin-bottom: 8px;
+      }
+
+      .trusted-add input[type="text"] {
+        flex: 1;
+        min-width: 0;
+        padding: 6px 8px;
+        background: rgba(0, 0, 0, 0.4);
+        border: 1px solid rgba(37, 228, 255, 0.25);
+        color: #25e4ff;
+        font-family: 'Electrolize', sans-serif;
+        font-size: 11px;
+        letter-spacing: 0.05em;
+        outline: none;
+        transition: border-color 0.15s, box-shadow 0.15s;
+      }
+
+      .trusted-add input[type="text"]:focus {
+        border-color: rgba(37, 228, 255, 0.6);
+        box-shadow: 0 0 8px rgba(37, 228, 255, 0.2);
+      }
+
+      .trusted-add input[type="text"]::placeholder {
+        color: #3a5068;
+      }
+
+      .trusted-add .btn {
+        flex-shrink: 0;
+        width: auto;
+        padding: 6px 10px;
+      }
+
+      .trusted-list {
+        list-style: none;
+        margin-bottom: 8px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid #162a3f;
+      }
+
+      .trusted-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 4px 0;
+      }
+
+      .trusted-origin {
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 10px;
+        letter-spacing: 0.05em;
+        color: #25e4ff;
+      }
+
+      .trusted-remove {
+        flex-shrink: 0;
+        background: none;
+        border: 1px solid rgba(37, 228, 255, 0.18);
+        color: #6c84a2;
+        font-family: 'Electrolize', sans-serif;
+        font-size: 9px;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        padding: 3px 8px;
+        cursor: pointer;
+        transition: background 0.15s, border-color 0.15s, color 0.15s;
+      }
+
+      .trusted-remove:hover {
+        background: rgba(200, 0, 0, 0.1);
+        border-color: rgba(200, 80, 80, 0.5);
+        color: #ff7070;
+      }
+
+      .trusted-empty {
+        font-size: 9px;
+        letter-spacing: 0.05em;
+        color: #3a5068;
+        font-style: italic;
+        padding: 2px 0;
+      }
+
+      .trusted-status {
+        font-size: 9px;
+        letter-spacing: 0.05em;
+        color: #6c84a2;
+        min-height: 1.2em;
+        margin-bottom: 4px;
+      }
+
+      .trusted-status.error { color: #ff7070; }
+      .trusted-status.success { color: #3ac96b; }
     </style>
   </head>
   <body>
@@ -255,6 +357,14 @@
         </label>
         <p class="hint">You can also click the summary panel to toggle this.</p>
       </div>
+
+      <div class="section-label">Trusted Sites</div>
+      <div class="trusted-add">
+        <input type="text" id="trustedInput" placeholder="https://example.com" spellcheck="false" autocomplete="off">
+        <button class="btn" id="trustedAdd">Add</button>
+      </div>
+      <div class="trusted-status" id="trustedStatus"></div>
+      <ul class="trusted-list" id="trustedList"></ul>
 
       <div class="section-label">Cache</div>
       <div class="actions">

--- a/src/ui_resources/HangarXPLOR.Settings.js
+++ b/src/ui_resources/HangarXPLOR.Settings.js
@@ -125,34 +125,20 @@ function registerRelayForOrigin(pattern) {
                 excludeMatches: RSI_EXCLUDE,
                 js: [RELAY_SCRIPT_FILE],
                 runAt: 'document_start'
-            }], function() {
-                if (chrome.runtime.lastError) {
-                    console.warn('HangarXPLOR: failed to register relay for', pattern, chrome.runtime.lastError.message);
-                }
-            });
+            }]);
         }
     });
 }
 
 function unregisterRelayForOrigin(pattern) {
-    chrome.scripting.unregisterContentScripts({ ids: [relayIdForPattern(pattern)] }, function() {
-        if (chrome.runtime.lastError) {
-            var msg = chrome.runtime.lastError.message || '';
-            if (msg.indexOf('Nonexistent script ID') === -1) {
-                console.warn('HangarXPLOR: failed to unregister relay for', pattern, msg);
-            }
-        }
-    });
+    chrome.scripting.unregisterContentScripts({ ids: [relayIdForPattern(pattern)] });
 }
 
 // Walk the trusted-sites list and make sure every entry has a relay registered, and no orphan relays remain for 
 // origins that are no longer trusted. Runs after reconcileAndRender writes the storage.
 function syncRelayRegistrations(trustedPatterns) {
     chrome.scripting.getRegisteredContentScripts({}, function(registered) {
-        if (chrome.runtime.lastError) {
-            console.warn('HangarXPLOR: cannot list registered scripts', chrome.runtime.lastError.message);
-            return;
-        }
+        if (chrome.runtime.lastError) return;
 
         var wantedSet = {};
         trustedPatterns.forEach(function(p) { wantedSet[relayIdForPattern(p)] = p });
@@ -170,11 +156,7 @@ function syncRelayRegistrations(trustedPatterns) {
         // Unregister any registered-but-unwanted.
         var toUnregister = Object.keys(haveSet).filter(function(id) { return !wantedSet[id] });
         if (toUnregister.length > 0) {
-            chrome.scripting.unregisterContentScripts({ ids: toUnregister }, function() {
-                if (chrome.runtime.lastError) {
-                    console.warn('HangarXPLOR: failed to prune relays', chrome.runtime.lastError.message);
-                }
-            });
+            chrome.scripting.unregisterContentScripts({ ids: toUnregister });
         }
     });
 }

--- a/src/ui_resources/HangarXPLOR.Settings.js
+++ b/src/ui_resources/HangarXPLOR.Settings.js
@@ -241,10 +241,6 @@ function addTrusted() {
 
     setStatus('Requesting ' + pattern + ' ...');
 
-    // Firefox requires permissions.request to be called synchronously inside the user-gesture handler. Any async hop
-    // before this call (e.g. chrome.storage.sync.get) breaks the gesture chain and Firefox rejects the dialog silently.
-    // Chrome tolerates the async hop; Firefox does not. Dedup is handled by the onAdded listener, which already noops
-    // when the origin is already in the stored list — so no pre-check needed here.
     chrome.permissions.request({ origins: [pattern] }, function(granted) {
         if (chrome.runtime.lastError) {
             setStatus(chrome.runtime.lastError.message || 'Permission request failed.', 'error');
@@ -254,8 +250,7 @@ function addTrusted() {
         if (!granted) {
             setStatus('Permission declined.', 'error');
         }
-        // Success path: onAdded handles storage + render. Nothing to
-        // do here — and the popup is probably gone anyway.
+
     });
 }
 

--- a/src/ui_resources/HangarXPLOR.Settings.js
+++ b/src/ui_resources/HangarXPLOR.Settings.js
@@ -93,7 +93,9 @@ function writeTrustedSites(sites, callback) {
     chrome.storage.sync.set({ _setting_TrustedSites: sites }, callback || function() {});
 }
 
-var RELAY_SCRIPT_FILE = 'content_scripts/trusted-site-relay.js';
+// Leading slash forces resolution from extension root on both browsers. Firefox otherwise resolves this relative to
+// the popup's URL (moz-extension://.../ui_resources/), producing a 404.
+var RELAY_SCRIPT_FILE = '/content_scripts/trusted-site-relay.js';
 var RELAY_ID_PREFIX   = 'trusted-site-relay:';
 var RSI_EXCLUDE = [
     'https://robertsspaceindustries.com/*',

--- a/src/ui_resources/HangarXPLOR.Settings.js
+++ b/src/ui_resources/HangarXPLOR.Settings.js
@@ -39,3 +39,220 @@ document.getElementById('clearCache').addEventListener('click', function() {
         });
     });
 });
+
+// Add, list, and remove user-trusted origins. Each add triggers chrome.permissions.request.
+var trustedInput  = document.getElementById('trustedInput');
+var trustedAdd    = document.getElementById('trustedAdd');
+var trustedList   = document.getElementById('trustedList');
+var trustedStatus = document.getElementById('trustedStatus');
+
+// Normalize whatever the user typed to an origin pattern that chrome.permissions.request accepts.
+//
+// NOTE: Chrome's match-pattern grammar doesn't include port numbers — the hostname is taken from `url.hostname` (which
+// strips the port) and the path is always normalized to `/*` (permissions are origin-scoped, not path-scoped). HTTP is
+// allowed only for `localhost`; all other hosts must use HTTPS.
+function normalizeOrigin(raw) {
+    var trimmed = (raw || '').trim();
+    if (trimmed.length === 0) return null;
+
+    var url;
+    try {
+        // URL with no scheme throws; scheme-less inputs get https:// prepended.
+        url = new URL(/^https?:\/\//i.test(trimmed) ? trimmed : 'https://' + trimmed);
+    } catch (e) {
+        return null;
+    }
+
+    if (url.hostname.length === 0) return null;
+
+    var isLocalhost = url.hostname === 'localhost';
+
+    if (url.protocol === 'https:') {
+        return 'https://' + url.hostname + '/*';
+    }
+
+    if (url.protocol === 'http:' && isLocalhost) {
+        return 'http://localhost/*';
+    }
+
+    return null;
+}
+
+function setStatus(message, kind) {
+    trustedStatus.textContent = message || '';
+    trustedStatus.className = 'trusted-status' + (kind ? ' ' + kind : '');
+}
+
+function readTrustedSites(callback) {
+    chrome.storage.sync.get({ _setting_TrustedSites: [] }, function(settings) {
+        callback(settings._setting_TrustedSites || []);
+    });
+}
+
+function writeTrustedSites(sites, callback) {
+    chrome.storage.sync.set({ _setting_TrustedSites: sites }, callback || function() {});
+}
+
+// Reconcile our stored trusted-sites list with Chrome's actual granted origins. Runs on every popup open and catches 
+// drift against Chrome's list of trusted sites for the extension (i.e. chrome://extensions/?id=<hangarXPLOR_id> sites)
+function reconcileAndRender() {
+    chrome.permissions.getAll(function(perms) {
+        var chromeOrigins = (perms.origins || []).filter(function(o) {
+            return o.indexOf('robertsspaceindustries.com') === -1;
+        });
+
+        readTrustedSites(function(storedSites) {
+            // Chrome is source of truth
+            var storedSet = {};
+            storedSites.forEach(function(o) { storedSet[o] = true });
+            var chromeSet = {};
+            chromeOrigins.forEach(function(o) { chromeSet[o] = true });
+
+            var needsWrite = false;
+            if (chromeOrigins.length !== storedSites.length) {
+                needsWrite = true;
+            } else {
+                for (var i = 0; i < chromeOrigins.length; i++) {
+                    if (!storedSet[chromeOrigins[i]]) { needsWrite = true; break }
+                }
+            }
+
+            var renderFromStorage = function() {
+                trustedList.innerHTML = '';
+
+                if (chromeOrigins.length === 0) {
+                    var empty = document.createElement('li');
+                    empty.className = 'trusted-empty';
+                    empty.textContent = 'No trusted sites yet.';
+                    trustedList.appendChild(empty);
+                    return;
+                }
+
+                chromeOrigins.forEach(function(origin) {
+                    var li = document.createElement('li');
+                    li.className = 'trusted-row';
+
+                    var label = document.createElement('span');
+                    label.className = 'trusted-origin';
+                    label.textContent = origin;
+                    label.title = origin;
+
+                    var remove = document.createElement('button');
+                    remove.className = 'trusted-remove';
+                    remove.textContent = 'Remove';
+                    remove.addEventListener('click', function() { removeTrusted(origin); });
+
+                    li.appendChild(label);
+                    li.appendChild(remove);
+                    trustedList.appendChild(li);
+                });
+            };
+
+            if (needsWrite) {
+                writeTrustedSites(chromeOrigins, renderFromStorage);
+            } else {
+                renderFromStorage();
+            }
+        });
+    });
+}
+
+// Backward-compat alias for existing call sites.
+var renderTrustedList = reconcileAndRender;
+
+function addTrusted() {
+    var pattern = normalizeOrigin(trustedInput.value);
+
+    if (pattern === null) {
+        setStatus('Enter an https origin (e.g. https://example.com) — or http://localhost for development.', 'error');
+        return;
+    }
+
+    readTrustedSites(function(sites) {
+        if (sites.indexOf(pattern) !== -1) {
+            setStatus('Already trusted.', 'error');
+            return;
+        }
+
+        setStatus('Requesting ' + pattern + ' ...');
+
+        chrome.permissions.request({ origins: [pattern] }, function(granted) {
+            if (chrome.runtime.lastError) {
+                setStatus(chrome.runtime.lastError.message || 'Permission request failed.', 'error');
+                return;
+            }
+
+            if (!granted) {
+                setStatus('Permission declined.', 'error');
+            }
+            // Success path: onAdded handles storage + render. Nothing to
+            // do here — and the popup is probably gone anyway.
+        });
+    });
+}
+
+function removeTrusted(pattern) {
+    // Revoke the permission; onRemoved listener handles storage + render
+    chrome.permissions.remove({ origins: [pattern] }, function(removed) {
+        if (chrome.runtime.lastError) {
+            setStatus(chrome.runtime.lastError.message || 'Permission remove failed.', 'error');
+            return;
+        }
+
+        if (!removed) {
+            // Permission wasn't held (user revoked it externally). Fall through to storage cleanup — onRemoved won't
+            // fire because there was nothing to remove from Chrome's perspective.
+            readTrustedSites(function(sites) {
+                writeTrustedSites(sites.filter(function(o) { return o !== pattern }), function() {
+                    setStatus('Removed from list (permission was already revoked)', 'success');
+                    renderTrustedList();
+                });
+            });
+        }
+        // removed === true: onRemoved listener will clean storage + render.
+    });
+}
+
+// Extension-scope permission events — fire regardless of which context initiated the request, and critically, survive
+// the popup being torn down by Chrome's native permission dialog
+chrome.permissions.onAdded.addListener(function(permissions) {
+    if (!permissions.origins || permissions.origins.length === 0) return;
+
+    readTrustedSites(function(sites) {
+        var added = [];
+        permissions.origins.forEach(function(origin) {
+            if (sites.indexOf(origin) === -1) {
+                sites.push(origin);
+                added.push(origin);
+            }
+        });
+        if (added.length === 0) return;
+        writeTrustedSites(sites, function() {
+            trustedInput.value = '';
+            setStatus('Added ' + added.join(', '), 'success');
+            renderTrustedList();
+        });
+    });
+});
+
+chrome.permissions.onRemoved.addListener(function(permissions) {
+    if (!permissions.origins || permissions.origins.length === 0) return;
+
+    readTrustedSites(function(sites) {
+        var removedSet = {};
+        permissions.origins.forEach(function(origin) { removedSet[origin] = true });
+        var filtered = sites.filter(function(o) { return !removedSet[o] });
+        if (filtered.length === sites.length) return;
+        writeTrustedSites(filtered, function() {
+            setStatus('Removed ' + permissions.origins.join(', '), 'success');
+            renderTrustedList();
+        });
+    });
+});
+
+trustedAdd.addEventListener('click', addTrusted);
+trustedInput.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') addTrusted();
+});
+
+renderTrustedList();

--- a/src/ui_resources/HangarXPLOR.Settings.js
+++ b/src/ui_resources/HangarXPLOR.Settings.js
@@ -255,26 +255,23 @@ function addTrusted() {
         return;
     }
 
-    readTrustedSites(function(sites) {
-        if (sites.indexOf(pattern) !== -1) {
-            setStatus('Already trusted.', 'error');
+    setStatus('Requesting ' + pattern + ' ...');
+
+    // Firefox requires permissions.request to be called synchronously inside the user-gesture handler. Any async hop
+    // before this call (e.g. chrome.storage.sync.get) breaks the gesture chain and Firefox rejects the dialog silently.
+    // Chrome tolerates the async hop; Firefox does not. Dedup is handled by the onAdded listener, which already noops
+    // when the origin is already in the stored list — so no pre-check needed here.
+    chrome.permissions.request({ origins: [pattern] }, function(granted) {
+        if (chrome.runtime.lastError) {
+            setStatus(chrome.runtime.lastError.message || 'Permission request failed.', 'error');
             return;
         }
 
-        setStatus('Requesting ' + pattern + ' ...');
-
-        chrome.permissions.request({ origins: [pattern] }, function(granted) {
-            if (chrome.runtime.lastError) {
-                setStatus(chrome.runtime.lastError.message || 'Permission request failed.', 'error');
-                return;
-            }
-
-            if (!granted) {
-                setStatus('Permission declined.', 'error');
-            }
-            // Success path: onAdded handles storage + render. Nothing to
-            // do here — and the popup is probably gone anyway.
-        });
+        if (!granted) {
+            setStatus('Permission declined.', 'error');
+        }
+        // Success path: onAdded handles storage + render. Nothing to
+        // do here — and the popup is probably gone anyway.
     });
 }
 

--- a/src/ui_resources/HangarXPLOR.Settings.js
+++ b/src/ui_resources/HangarXPLOR.Settings.js
@@ -93,6 +93,90 @@ function writeTrustedSites(sites, callback) {
     chrome.storage.sync.set({ _setting_TrustedSites: sites }, callback || function() {});
 }
 
+var RELAY_SCRIPT_FILE = 'content_scripts/trusted-site-relay.js';
+var RELAY_ID_PREFIX   = 'trusted-site-relay:';
+var RSI_EXCLUDE = [
+    'https://robertsspaceindustries.com/*',
+    'https://*.robertsspaceindustries.com/*'
+];
+
+function relayIdForPattern(pattern) {
+    return RELAY_ID_PREFIX + pattern;
+}
+
+function registerRelayForOrigin(pattern) {
+    chrome.scripting.registerContentScripts([{
+        id: relayIdForPattern(pattern),
+        matches: [pattern],
+        excludeMatches: RSI_EXCLUDE,
+        js: [RELAY_SCRIPT_FILE],
+        runAt: 'document_start',
+        persistAcrossSessions: true,
+        world: 'ISOLATED'
+    }], function() {
+        if (chrome.runtime.lastError) {
+            // Apparently the most common cause of error is that the script is already installed. We will then try to
+            // update instead.
+            chrome.scripting.updateContentScripts([{
+                id: relayIdForPattern(pattern),
+                matches: [pattern],
+                excludeMatches: RSI_EXCLUDE,
+                js: [RELAY_SCRIPT_FILE],
+                runAt: 'document_start'
+            }], function() {
+                if (chrome.runtime.lastError) {
+                    console.warn('HangarXPLOR: failed to register relay for', pattern, chrome.runtime.lastError.message);
+                }
+            });
+        }
+    });
+}
+
+function unregisterRelayForOrigin(pattern) {
+    chrome.scripting.unregisterContentScripts({ ids: [relayIdForPattern(pattern)] }, function() {
+        if (chrome.runtime.lastError) {
+            var msg = chrome.runtime.lastError.message || '';
+            if (msg.indexOf('Nonexistent script ID') === -1) {
+                console.warn('HangarXPLOR: failed to unregister relay for', pattern, msg);
+            }
+        }
+    });
+}
+
+// Walk the trusted-sites list and make sure every entry has a relay registered, and no orphan relays remain for 
+// origins that are no longer trusted. Runs after reconcileAndRender writes the storage.
+function syncRelayRegistrations(trustedPatterns) {
+    chrome.scripting.getRegisteredContentScripts({}, function(registered) {
+        if (chrome.runtime.lastError) {
+            console.warn('HangarXPLOR: cannot list registered scripts', chrome.runtime.lastError.message);
+            return;
+        }
+
+        var wantedSet = {};
+        trustedPatterns.forEach(function(p) { wantedSet[relayIdForPattern(p)] = p });
+
+        var haveSet = {};
+        registered.forEach(function(s) {
+            if (s.id && s.id.indexOf(RELAY_ID_PREFIX) === 0) haveSet[s.id] = true;
+        });
+
+        // Register any wanted-but-missing.
+        Object.keys(wantedSet).forEach(function(id) {
+            if (!haveSet[id]) registerRelayForOrigin(wantedSet[id]);
+        });
+
+        // Unregister any registered-but-unwanted.
+        var toUnregister = Object.keys(haveSet).filter(function(id) { return !wantedSet[id] });
+        if (toUnregister.length > 0) {
+            chrome.scripting.unregisterContentScripts({ ids: toUnregister }, function() {
+                if (chrome.runtime.lastError) {
+                    console.warn('HangarXPLOR: failed to prune relays', chrome.runtime.lastError.message);
+                }
+            });
+        }
+    });
+}
+
 // Reconcile our stored trusted-sites list with Chrome's actual granted origins. Runs on every popup open and catches 
 // drift against Chrome's list of trusted sites for the extension (i.e. chrome://extensions/?id=<hangarXPLOR_id> sites)
 function reconcileAndRender() {
@@ -153,6 +237,9 @@ function reconcileAndRender() {
             } else {
                 renderFromStorage();
             }
+
+            // Keep relay registrations in sync with the reconciled list.
+            syncRelayRegistrations(chromeOrigins);
         });
     });
 }
@@ -231,6 +318,8 @@ chrome.permissions.onAdded.addListener(function(permissions) {
             trustedInput.value = '';
             setStatus('Added ' + added.join(', '), 'success');
             renderTrustedList();
+            // Register the relay for each newly-added origin.
+            added.forEach(registerRelayForOrigin);
         });
     });
 });
@@ -246,6 +335,8 @@ chrome.permissions.onRemoved.addListener(function(permissions) {
         writeTrustedSites(filtered, function() {
             setStatus('Removed ' + permissions.origins.join(', '), 'success');
             renderTrustedList();
+            // Unregister relays for origins that lost their grant.
+            permissions.origins.forEach(unregisterRelayForOrigin);
         });
     });
 });

--- a/src/web_resources/HangarXPLOR.BulkUI.js
+++ b/src/web_resources/HangarXPLOR.BulkUI.js
@@ -35,7 +35,7 @@ HangarXPLOR.BulkUI = function()
   HangarXPLOR.$bulkUI.$inner = $('<div>', { class: 'inner content-block1 loading' });
   HangarXPLOR.$bulkUI.$value = $('<div>', { class: 'value' });
   HangarXPLOR.$bulkUI.$actions = $('<div>', { class: 'actions' });
-  HangarXPLOR.$bulkUI.$downloads = $('<div>', { class: 'actions' });
+  HangarXPLOR.$bulkUI.$downloads = $('<div>', { class: 'actions downloads' });
   HangarXPLOR.$bulkUI.$loading = $('<div>', { class: 'status value' });
   
   HangarXPLOR.$bulkUI.addClass(HangarXPLOR._feature.Summary);
@@ -54,6 +54,8 @@ HangarXPLOR.BulkUI = function()
   
   HangarXPLOR.$bulkUI.$downloads.append(HangarXPLOR.Button('Download CSV', 'download js-download-csv', HangarXPLOR._callbacks.DownloadCSV));
   HangarXPLOR.$bulkUI.$downloads.append(HangarXPLOR.Button('Download JSON', 'download js-download-json', HangarXPLOR._callbacks.DownloadJSON));
+  HangarXPLOR.$bulkUI.$downloads.append(HangarXPLOR.Button('Download Upgrades CSV', 'download js-download-upgrades-csv', HangarXPLOR._callbacks.DownloadUpgradesCSV));
+  HangarXPLOR.$bulkUI.$downloads.append(HangarXPLOR.Button('Download Upgrades JSON', 'download js-download-upgrades-json', HangarXPLOR._callbacks.DownloadUpgradesJSON));
 
   bulkHeight = $('.js-bulk-ui').height();
   positionUI();

--- a/src/web_resources/HangarXPLOR.BulkUI.js
+++ b/src/web_resources/HangarXPLOR.BulkUI.js
@@ -124,6 +124,22 @@ HangarXPLOR.MarkLoadingComplete = function()
 {
   HangarXPLOR.$bulkUI.$loading.empty();
   HangarXPLOR.$bulkUI.$inner.removeClass('still-loading');
+
+  // Phase 2 of trusted-sites: snapshot the parsed inventory so the relay content script (running on trusted origins) 
+  // can serve it without having to access the RSI tab. Last load always wins.
+  if (typeof HangarXPLOR.GetCombinedList === 'function' && chrome && chrome.storage && chrome.storage.local) {
+    try {
+      var combined = HangarXPLOR.GetCombinedList($(HangarXPLOR._inventory));
+      var snapshot = {
+        generatedAt: new Date().toISOString(),
+        ships:       combined.ships,
+        upgrades:    combined.upgrades
+      };
+      chrome.storage.local.set({ 'cache:parsed_export': snapshot });
+    } catch (e) {
+      HangarXPLOR.Log('snapshot failed', e);
+    }
+  }
 }
 
 HangarXPLOR.RefreshBulkUI = function()

--- a/src/web_resources/HangarXPLOR.Download.js
+++ b/src/web_resources/HangarXPLOR.Download.js
@@ -87,9 +87,9 @@ HangarXPLOR._exportByName = HangarXPLOR._exportByName || {};
   
   HangarXPLOR._callbacks.DownloadCSV = function(e) {
     e.preventDefault();
-    
+
     var $target = $(HangarXPLOR._selected.length > 0 ? HangarXPLOR._selected : HangarXPLOR._inventory);
-    
+
     // TODO: CSV support will need to be careful of user-entered data...
     var buffer = "Manufacturer, Ship, Lti, Warbond, ID, Pledge, Cost, Date\n";
     buffer = buffer + HangarXPLOR.GetShipList($target).map(function(ship) { return [ '"' + ship.manufacturer_name + '"', '"' + ship.ship_name + '"', ship.lti, ship.warbond, ship.pledge_id, '"' + ship.pledge_name + '"', '"' + ship.pledge_cost + '"', '"' + ship.pledge_date + '"' ].join(',')}).join('\n')
@@ -97,6 +97,74 @@ HangarXPLOR._exportByName = HangarXPLOR._exportByName || {};
     $download.attr('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(buffer));
     $download.attr('download', 'shiplist.csv');
     $download.attr('type', 'text/csv');
+    $download[0].click();
+  }
+
+  HangarXPLOR.GetUpgradeList = function($target) {
+
+    return $target.map(function() {
+      var $pledge = this;
+
+      if (!this.filters || !this.filters.is_upgrade) return null;
+
+      var upgrade = this.upgrade_data ? { ...this.upgrade_data } : {};
+
+      upgrade.entity_type = 'upgrade';
+      upgrade.lti         = this.filters.is_lti === true;
+      upgrade.warbond     = this.filters.is_warbond === true;
+      upgrade.pledge_id   = $('.js-pledge-id', $pledge).val();
+      upgrade.pledge_name = $('.js-pledge-name', $pledge).val();
+      upgrade.pledge_date = $('.date-col:first', $pledge).text().replace(/created:\s+/gi, '').trim();
+      upgrade.pledge_cost = $('.js-pledge-value', $pledge).val();
+
+      return upgrade;
+    }).get().filter(function(upgrade) { return upgrade !== null });
+  }
+
+  HangarXPLOR.GetCombinedList = function($target) {
+    return {
+      ships:    HangarXPLOR.GetShipList($target),
+      upgrades: HangarXPLOR.GetUpgradeList($target)
+    };
+  }
+
+  HangarXPLOR._callbacks.DownloadUpgradesJSON = function(e) {
+    e.preventDefault();
+
+    var $target = $(HangarXPLOR._selected.length > 0 ? HangarXPLOR._selected : HangarXPLOR._inventory);
+
+    $download.attr('href', 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(HangarXPLOR.GetUpgradeList($target), null, 2)));
+    $download.attr('download', 'upgradelist.json');
+    $download.attr('type', 'text/json');
+    $download[0].click();
+  }
+
+  HangarXPLOR._callbacks.DownloadUpgradesCSV = function(e) {
+    e.preventDefault();
+
+    var $target = $(HangarXPLOR._selected.length > 0 ? HangarXPLOR._selected : HangarXPLOR._inventory);
+
+    var buffer = "Pledge ID, Pledge, Cost, Date, Upgrade ID, Upgrade, From, To, Lti, Warbond\n";
+    buffer = buffer + HangarXPLOR.GetUpgradeList($target).map(function(upgrade) {
+      var from_name = upgrade.match_items && upgrade.match_items[0] ? upgrade.match_items[0].name : '';
+      var to_name   = upgrade.target_items && upgrade.target_items[0] ? upgrade.target_items[0].name : '';
+      return [ upgrade.pledge_id, '"' + upgrade.pledge_name + '"', '"' + upgrade.pledge_cost + '"', '"' + upgrade.pledge_date + '"', upgrade.id, '"' + upgrade.name + '"', '"' + from_name + '"', '"' + to_name + '"', upgrade.lti, upgrade.warbond ].join(',');
+    }).join('\n')
+
+    $download.attr('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(buffer));
+    $download.attr('download', 'upgradelist.csv');
+    $download.attr('type', 'text/csv');
+    $download[0].click();
+  }
+
+  HangarXPLOR._callbacks.DownloadCombinedJSON = function(e) {
+    e.preventDefault();
+
+    var $target = $(HangarXPLOR._selected.length > 0 ? HangarXPLOR._selected : HangarXPLOR._inventory);
+
+    $download.attr('href', 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(HangarXPLOR.GetCombinedList($target), null, 2)));
+    $download.attr('download', 'hangar.json');
+    $download.attr('type', 'text/json');
     $download[0].click();
   }
 })();

--- a/src/web_resources/HangarXPLOR.css
+++ b/src/web_resources/HangarXPLOR.css
@@ -26,6 +26,8 @@
 .js-bulk-ui .value .label-short { width: 40px; }
 .js-bulk-ui .actions a { margin-left: 20px; margin-top: 5px; }
 .js-bulk-ui .actions a:first-child { margin-left: 0px !important; }
+.js-bulk-ui .actions.downloads { display: grid; grid-template-columns: 1fr 1fr; column-gap: 20px; row-gap: 5px; }
+.js-bulk-ui .actions.downloads a { margin-left: 0 !important; margin-top: 0 !important; }
 .js-bulk-ui .status { display: none; }
 .js-bulk-ui .loading .actions,
 .js-bulk-ui .loading .value { display: none; }


### PR DESCRIPTION
- new ui, allowing users to add trusted domains (calls browser api, screenshots below)
- added a way for consumers to get data from HangarXPLOR if and only if they're trusted explicitly by the user
- consumers _must_ be behind https
- added an explicit localhost carve-out for devs, only url allowed to be http (must be explicitly added with http protocol)

I also stacked this on top of the upgrade export PR because I already wrote a combined export function there. If #144 doesn't get accepted but you want this one, I can rewrite it. Otherwise, this is in draft because I'll have to rebase over release before this can be merged.

### How it works
- User signs into RSI website, visits their hangar. In the background, we're saving the data export to extension storage i.e. no other extension has access to this data
- On trusted sites, consumers can post a message, and HangarXPLOR will respond with the data.
- Biggest change is that content script: it's an iife who's only job is to respond to messages with storage data. It's run on every trusted site, giving consumers an API (ish) to get data. Also, because of the content script, `scripting` was added to the manifest.
- On data audit, the only thing in there that I think would be considered sensitive is pledge_id, but the API already exports that, so I think it's fine.

```js
// Excuse the typos, typed this in an HTML input box

// First, add an event listener to the window. We specifically are looking for _our_ response kind.
window.addEventListener('message', e => {
  if (e.data?.type === 'HangarXPLOR:response') {
     console.log(e.data); // the payload consumers can work with
  }
})

// Once the listener is installed, the consumer can post a message to the window:
window.postMessage({ type: 'HangarXPLOR:request', requestId: 'some-long-uuid'}, location.origin);

// The above will yield data (we console.log'd in the event listener above so in console, you'll see:
// { type: 'HangarXPLOR:response', requestId: 'some-long-uuid', status: 'ok', data: { ... } }
```

### Screenshots



<img width="349" height="557" alt="Screenshot 2026-04-19 155601" src="https://github.com/user-attachments/assets/5a2b3e67-54e2-49a7-9af1-0196dddfbb01" />

> Trusted sites section




<img width="486" height="242" alt="Screenshot 2026-04-19 160156" src="https://github.com/user-attachments/assets/5c6fb151-c524-4bf9-b3d7-25b77f0bd53e" />

> Popup when adding a site (chrome)


<img width="451" height="208" alt="Screenshot 2026-04-19 184448" src="https://github.com/user-attachments/assets/28402644-2da9-4495-b59c-e79f489f1cb3" />

> Popup when adding a site (firefox)

Tested on:
- Mozilla Firefox (149.0.2)
- Chromium: 147.0.7727.102